### PR TITLE
Refactor initialization and re-order methods

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -13,7 +13,7 @@ import time
 
 from rendercanvas.auto import RenderCanvas, loop
 
-from cube import setup_drawing_sync
+from rendercanvas.utils.cube import setup_drawing_sync
 
 
 canvas = RenderCanvas(

--- a/examples/qt_app.py
+++ b/examples/qt_app.py
@@ -31,7 +31,7 @@ class ExampleWidget(QtWidgets.QWidget):
         splitter = QtWidgets.QSplitter()
 
         self.button = QtWidgets.QPushButton("Hello world", self)
-        self.canvas = QRenderWidget(splitter)
+        self.canvas = QRenderWidget(splitter, update_mode="continuous")
         self.output = QtWidgets.QTextEdit(splitter)
 
         self.button.clicked.connect(self.whenButtonClicked)

--- a/examples/qt_app_asyncio.py
+++ b/examples/qt_app_asyncio.py
@@ -49,7 +49,7 @@ class ExampleWidget(QtWidgets.QWidget):
 
         # todo: use update_mode = 'continuous' when that feature has arrived
         self.button = QtWidgets.QPushButton("Hello world", self)
-        self.canvas = QRenderWidget(splitter)
+        self.canvas = QRenderWidget(splitter, update_mode="continuous")
         self.output = QtWidgets.QTextEdit(splitter)
 
         # self.button.clicked.connect(self.whenButtonClicked)  # see above :(

--- a/examples/wx_app.py
+++ b/examples/wx_app.py
@@ -2,6 +2,8 @@
 An example demonstrating a wx app with a wgpu viz inside.
 """
 
+import time
+
 import wx
 from rendercanvas.wx import RenderWidget
 
@@ -13,30 +15,35 @@ class Example(wx.Frame):
         super().__init__(None, title="wgpu triangle embedded in a wx app")
         self.SetSize(640, 480)
 
-        splitter = wx.SplitterWindow(self)
-
+        # Using present_method 'image' because it reports "The surface texture is suboptimal"
+        self.canvas = RenderWidget(
+            self, update_mode="continuous", present_method="image"
+        )
         self.button = wx.Button(self, -1, "Hello world")
-        self.canvas1 = RenderWidget(splitter)
-        self.canvas2 = RenderWidget(splitter)
-
-        splitter.SplitVertically(self.canvas1, self.canvas2)
-        splitter.SetSashGravity(0.5)
+        self.output = wx.StaticText(self)
 
         sizer = wx.BoxSizer(wx.HORIZONTAL)
         sizer.Add(self.button, 0, wx.EXPAND)
-        sizer.Add(splitter, 1, wx.EXPAND)
+        sizer.Add(self.canvas, 1, wx.EXPAND)
+        sizer.Add(self.output, 1, wx.EXPAND)
         self.SetSizer(sizer)
 
+        self.button.Bind(wx.EVT_BUTTON, self.OnClicked)
+
+        # Force the canvas to be shown, so that it gets a valid handle.
+        # Otherwise GetHandle() is initially 0, and getting a surface will fail.
         self.Show()
+
+    def OnClicked(self, event):  # noqa: N802
+        t = self.output.GetLabel()
+        t += f"\nClicked at {time.time():0.1f}"
+        self.output.SetLabel(t)
 
 
 app = wx.App()
 example = Example()
 
-draw_frame1 = setup_drawing_sync(example.canvas1)
-draw_frame2 = setup_drawing_sync(example.canvas2)
-
-example.canvas1.request_draw(draw_frame1)
-example.canvas2.request_draw(draw_frame2)
+draw_frame = setup_drawing_sync(example.canvas)
+example.canvas.request_draw(draw_frame)
 
 app.MainLoop()

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -352,7 +352,10 @@ class BaseRenderCanvas:
 
     def set_logical_size(self, width, height):
         """Set the window size (in logical pixels)."""
-        self._rc_set_logical_size(float(width), float(height))
+        width, height = float(width), float(height)
+        if width < 0 or height < 0:
+            raise ValueError("Canvas width and height must not be negative")
+        self._rc_set_logical_size(width, height)
 
     def set_title(self, title):
         """Set the window title."""

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -146,22 +146,20 @@ class GlfwRenderCanvas(BaseRenderCanvas):
 
     # See https://www.glfw.org/docs/latest/group__window.html
 
-    def __init__(self, *, size=None, title=None, **kwargs):
+    def _rc_init(self, *, present_method, **_):
         loop.init_glfw()
-        super().__init__(**kwargs)
 
-        # Handle inputs
-        if title is None:
-            title = "glfw canvas"
-        if not size:
-            size = 640, 480
+        if present_method == "image":
+            logger.warning(
+                "Ignoreing present_method 'image'; glfw can only render to screen"
+            )
 
         # Set window hints
         glfw.window_hint(glfw.CLIENT_API, glfw.NO_API)
         glfw.window_hint(glfw.RESIZABLE, True)
 
         # Create the window (the initial size may not be in logical pixels)
-        self._window = glfw.create_window(int(size[0]), int(size[1]), title, None, None)
+        self._window = glfw.create_window(640, 480, "", None, None)
 
         # Other internal variables
         self._changing_pixel_ratio = False
@@ -197,49 +195,13 @@ class GlfwRenderCanvas(BaseRenderCanvas):
         self._pixel_ratio = -1
         self._screen_size_is_logical = False
 
-        # Apply incoming args via the proper route
-        self.set_logical_size(*size)
-        self.set_title(title)
-
-    # Callbacks to provide a minimal working canvas
-
-    def _on_pixelratio_change(self, *args):
-        if self._changing_pixel_ratio:
-            return
-        self._changing_pixel_ratio = True  # prevent recursion (on Wayland)
-        try:
-            self._set_logical_size(self._logical_size)
-        finally:
-            self._changing_pixel_ratio = False
-        self.request_draw()
-
-    def _on_size_change(self, *args):
-        self._determine_size()
-        self.request_draw()
-
-    def _check_close(self, *args):
-        # Follow the close flow that glfw intended.
-        # This method can be overloaded and the close-flag can be set to False
-        # using set_window_should_close() if now is not a good time to close.
-        if self._window is not None and glfw.window_should_close(self._window):
-            self._on_close()
-
-    def _on_close(self, *args):
-        loop.all_glfw_canvases.discard(self)
-        if self._window is not None:
-            glfw.destroy_window(self._window)  # not just glfw.hide_window
-            self._window = None
-            self.submit_event({"event_type": "close"})
-
     def _on_window_dirty(self, *args):
         self.request_draw()
 
     def _on_iconify(self, window, iconified):
         self._is_minimized = bool(iconified)
         if not self._is_minimized:
-            self._request_draw()
-
-    # helpers
+            self._rc_request_draw()
 
     def _determine_size(self):
         if self._window is None:
@@ -261,6 +223,8 @@ class GlfwRenderCanvas(BaseRenderCanvas):
             "pixel_ratio": self._pixel_ratio,
         }
         self.submit_event(ev)
+
+    # %% Methods to implement RenderCanvas
 
     def _set_logical_size(self, new_logical_size):
         if self._window is None:
@@ -298,47 +262,79 @@ class GlfwRenderCanvas(BaseRenderCanvas):
         if pixel_ratio != self._pixel_ratio:
             self._determine_size()
 
-    # API
-
-    def _get_loop(self):
+    def _rc_get_loop(self):
         return loop
 
-    def _request_draw(self):
+    def _rc_get_present_info(self):
+        return get_glfw_present_info(self._window)
+
+    def _rc_request_draw(self):
         if not self._is_minimized:
             loop.call_soon(self._draw_frame_and_present)
 
-    def _force_draw(self):
+    def _rc_force_draw(self):
         self._draw_frame_and_present()
 
-    def get_present_info(self):
-        return get_glfw_present_info(self._window)
+    def _rc_present_image(self, image, **kwargs):
+        raise NotImplementedError()
+        # AFAIK glfw does not have a builtin way to blit an image. It also does
+        # not really need one, since it's the most reliable backend to
+        # render to the screen.
 
-    def get_pixel_ratio(self):
-        return self._pixel_ratio
-
-    def get_logical_size(self):
-        return self._logical_size
-
-    def get_physical_size(self):
+    def _rc_get_physical_size(self):
         return self._physical_size
 
-    def set_logical_size(self, width, height):
+    def _rc_get_logical_size(self):
+        return self._logical_size
+
+    def _rc_get_pixel_ratio(self):
+        return self._pixel_ratio
+
+    def _rc_set_logical_size(self, width, height):
         if width < 0 or height < 0:
             raise ValueError("Window width and height must not be negative")
         self._set_logical_size((float(width), float(height)))
 
-    def _set_title(self, title):
-        glfw.set_window_title(self._window, title)
-
-    def close(self):
+    def _rc_close(self):
         if self._window is not None:
             glfw.set_window_should_close(self._window, True)
             self._check_close()
 
-    def is_closed(self):
+    def _rc_is_closed(self):
         return self._window is None
 
-    # User events
+    def _rc_set_title(self, title):
+        glfw.set_window_title(self._window, title)
+
+    # %% Turn glfw events into rendercanvas events
+
+    def _on_pixelratio_change(self, *args):
+        if self._changing_pixel_ratio:
+            return
+        self._changing_pixel_ratio = True  # prevent recursion (on Wayland)
+        try:
+            self._set_logical_size(self._logical_size)
+        finally:
+            self._changing_pixel_ratio = False
+        self.request_draw()
+
+    def _on_size_change(self, *args):
+        self._determine_size()
+        self.request_draw()
+
+    def _check_close(self, *args):
+        # Follow the close flow that glfw intended.
+        # This method can be overloaded and the close-flag can be set to False
+        # using set_window_should_close() if now is not a good time to close.
+        if self._window is not None and glfw.window_should_close(self._window):
+            self._on_close()
+
+    def _on_close(self, *args):
+        loop.all_glfw_canvases.discard(self)
+        if self._window is not None:
+            glfw.destroy_window(self._window)  # not just glfw.hide_window
+            self._window = None
+            self.submit_event({"event_type": "close"})
 
     def _on_mouse_button(self, window, but, action, mods):
         # Map button being changed, which we use to update self._pointer_buttons.
@@ -514,12 +510,6 @@ class GlfwRenderCanvas(BaseRenderCanvas):
             "modifiers": tuple(self._key_modifiers),
         }
         self.submit_event(ev)
-
-    def present_image(self, image, **kwargs):
-        raise NotImplementedError()
-        # AFAIK glfw does not have a builtin way to blit an image. It also does
-        # not really need one, since it's the most reliable backend to
-        # render to the screen.
 
 
 # Make available under a name that is the same for all backends

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -147,9 +147,8 @@ class GlfwRenderCanvas(BaseRenderCanvas):
     # See https://www.glfw.org/docs/latest/group__window.html
 
     def __init__(self, *args, present_method=None, **kwargs):
-        super().__init__(*args, **kwargs)
-
         loop.init_glfw()
+        super().__init__(*args, **kwargs)
 
         if present_method == "image":
             logger.warning(

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -146,7 +146,9 @@ class GlfwRenderCanvas(BaseRenderCanvas):
 
     # See https://www.glfw.org/docs/latest/group__window.html
 
-    def _rc_init(self, *, present_method, **_):
+    def __init__(self, *args, present_method=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
         loop.init_glfw()
 
         if present_method == "image":
@@ -194,6 +196,9 @@ class GlfwRenderCanvas(BaseRenderCanvas):
         # Initialize the size
         self._pixel_ratio = -1
         self._screen_size_is_logical = False
+
+        # Set size, title, etc.
+        self._final_canvas_init()
 
     def _on_window_dirty(self, *args):
         self.request_draw()

--- a/rendercanvas/jupyter.py
+++ b/rendercanvas/jupyter.py
@@ -17,7 +17,9 @@ from IPython.display import display
 class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
     """An ipywidgets widget providing a render canvas. Needs the jupyter_rfb library."""
 
-    def _rc_init(self, **_):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         # Internal variables
         self._last_image = None
         self._pixel_ratio = 1
@@ -27,6 +29,9 @@ class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
 
         # Register so this can be display'ed when run() is called
         loop._pending_jupyter_canvases.append(weakref.ref(self))
+
+        # Set size, title, etc.
+        self._final_canvas_init()
 
     def get_frame(self):
         # The _draw_frame_and_present() does the drawing and then calls

--- a/rendercanvas/offscreen.py
+++ b/rendercanvas/offscreen.py
@@ -10,10 +10,9 @@ class ManualOffscreenRenderCanvas(BaseRenderCanvas):
     def __init__(self, *args, pixel_ratio=1.0, **kwargs):
         super().__init__(*args, **kwargs)
         self._pixel_ratio = pixel_ratio
-
-    def _rc_init(self, **_):
         self._closed = False
         self._last_image = None
+        self._final_canvas_init()
 
     # %% Methods to implement RenderCanvas
 

--- a/rendercanvas/offscreen.py
+++ b/rendercanvas/offscreen.py
@@ -7,55 +7,62 @@ class ManualOffscreenRenderCanvas(BaseRenderCanvas):
     Call the ``.draw()`` method to perform a draw and get the result.
     """
 
-    def __init__(self, *args, size=None, pixel_ratio=1, title=None, **kwargs):
+    def __init__(self, *args, pixel_ratio=1.0, **kwargs):
         super().__init__(*args, **kwargs)
-        self._logical_size = (float(size[0]), float(size[1])) if size else (640, 480)
         self._pixel_ratio = pixel_ratio
+
+    def _rc_init(self, **_):
         self._closed = False
         self._last_image = None
 
-    def get_present_info(self):
+    # %% Methods to implement RenderCanvas
+
+    def _rc_get_loop(self):
+        return None  # No scheduling
+
+    def _rc_get_present_info(self):
         return {
             "method": "image",
             "formats": ["rgba8unorm-srgb", "rgba8unorm"],
         }
 
-    def present_image(self, image, **kwargs):
-        self._last_image = image
-
-    def get_pixel_ratio(self):
-        return self._pixel_ratio
-
-    def get_logical_size(self):
-        return self._logical_size
-
-    def get_physical_size(self):
-        return int(self._logical_size[0] * self._pixel_ratio), int(
-            self._logical_size[1] * self._pixel_ratio
-        )
-
-    def set_logical_size(self, width, height):
-        self._logical_size = width, height
-
-    def _set_title(self, title):
-        pass
-
-    def close(self):
-        self._closed = True
-
-    def is_closed(self):
-        return self._closed
-
-    def _get_loop(self):
-        return None  # No scheduling
-
-    def _request_draw(self):
+    def _rc_request_draw(self):
         # Ok, cool, the scheduler want a draw. But we only draw when the user
         # calls draw(), so that's how this canvas ticks.
         pass
 
-    def _force_draw(self):
+    def _rc_force_draw(self):
         self._draw_frame_and_present()
+
+    def _rc_present_image(self, image, **kwargs):
+        self._last_image = image
+
+    def _rc_get_physical_size(self):
+        return int(self._logical_size[0] * self._pixel_ratio), int(
+            self._logical_size[1] * self._pixel_ratio
+        )
+
+    def _rc_get_logical_size(self):
+        return self._logical_size
+
+    def rc_get_pixel_ratio(self):
+        return self._pixel_ratio
+
+    def _rc_set_logical_size(self, width, height):
+        self._logical_size = width, height
+
+    def _rc_close(self):
+        self._closed = True
+
+    def _rc_is_closed(self):
+        return self._closed
+
+    def _rc_set_title(self, title):
+        pass
+
+    # %% events - there are no GUI events
+
+    # %% Extra API
 
     def draw(self):
         """Perform a draw and get the resulting image.

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -7,7 +7,12 @@ import sys
 import ctypes
 import importlib
 
-from .base import BaseRenderCanvas, BaseLoop, BaseTimer, pop_kwargs_for_base_canvas
+from .base import (
+    WrapperRenderCanvas,
+    BaseRenderCanvas,
+    BaseLoop,
+    BaseTimer,
+)
 from ._gui_utils import (
     logger,
     SYSTEM_IS_WAYLAND,
@@ -142,9 +147,7 @@ _show_image_method_warning = (
 class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
     """A QWidget representing a render canvas that can be embedded in a Qt application."""
 
-    def __init__(self, *args, present_method=None, **kwargs):
-        super().__init__(*args, **kwargs)
-
+    def _rc_init(self, *, present_method, **_):
         # Determine present method
         self._surface_ids = None
         if not present_method:
@@ -172,37 +175,6 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         self.setMouseTracking(True)
         self.setFocusPolicy(FocusPolicy.StrongFocus)
 
-    def paintEngine(self):  # noqa: N802 - this is a Qt method
-        # https://doc.qt.io/qt-5/qt.html#WidgetAttribute-enum  WA_PaintOnScreen
-        if self._present_to_screen:
-            return None
-        else:
-            return super().paintEngine()
-
-    def paintEvent(self, event):  # noqa: N802 - this is a Qt method
-        self._draw_frame_and_present()
-
-    def update(self):
-        # Bypass Qt's mechanics and request a draw so that the scheduling mechanics work as intended.
-        # Eventually this will call _request_draw().
-        self.request_draw()
-
-    # Methods that we add for BaseRenderCanvas (snake_case)
-
-    def _request_draw(self):
-        # Ask Qt to do a paint event
-        QtWidgets.QWidget.update(self)
-
-    def _force_draw(self):
-        # Call the paintEvent right now.
-        # This works on all platforms I tested, except on MacOS when drawing with the 'image' method.
-        # Not sure why this is. It be made to work by calling processEvents() but that has all sorts
-        # of nasty side-effects (e.g. the scheduler timer keeps ticking, invoking other draws, etc.).
-        self.repaint()
-
-    def _get_loop(self):
-        return loop
-
     def _get_surface_ids(self):
         if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
             return {
@@ -225,7 +197,29 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         else:
             raise RuntimeError(f"Cannot get Qt surface info on {sys.platform}.")
 
-    def get_present_info(self):
+    # %% Qt methods
+
+    def paintEngine(self):  # noqa: N802 - this is a Qt method
+        # https://doc.qt.io/qt-5/qt.html#WidgetAttribute-enum  WA_PaintOnScreen
+        if self._present_to_screen:
+            return None
+        else:
+            return super().paintEngine()
+
+    def paintEvent(self, event):  # noqa: N802 - this is a Qt method
+        self._draw_frame_and_present()
+
+    def update(self):
+        # Bypass Qt's mechanics and request a draw so that the scheduling mechanics work as intended.
+        # Eventually this will call _request_draw().
+        self.request_draw()
+
+    # %% Methods to implement RenderCanvas
+
+    def _rc_get_loop(self):
+        return loop
+
+    def _rc_get_present_info(self):
         global _show_image_method_warning
         if self._surface_ids is None:
             self._surface_ids = self._get_surface_ids()
@@ -242,18 +236,57 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
             }
         return info
 
-    def get_pixel_ratio(self):
-        # Observations:
-        # * On Win10 + PyQt5 the ratio is a whole number (175% becomes 2).
-        # * On Win10 + PyQt6 the ratio is correct (non-integer).
-        return self.devicePixelRatioF()
+    def _rc_request_draw(self):
+        # Ask Qt to do a paint event
+        QtWidgets.QWidget.update(self)
 
-    def get_logical_size(self):
-        # Sizes in Qt are logical
-        lsize = self.width(), self.height()
-        return float(lsize[0]), float(lsize[1])
+    def _rc_force_draw(self):
+        # Call the paintEvent right now.
+        # This works on all platforms I tested, except on MacOS when drawing with the 'image' method.
+        # Not sure why this is. It be made to work by calling processEvents() but that has all sorts
+        # of nasty side-effects (e.g. the scheduler timer keeps ticking, invoking other draws, etc.).
+        self.repaint()
 
-    def get_physical_size(self):
+    def _rc_present_image(self, image_data, **kwargs):
+        size = image_data.shape[1], image_data.shape[0]  # width, height
+        rect1 = QtCore.QRect(0, 0, size[0], size[1])
+        rect2 = self.rect()
+
+        painter = QtGui.QPainter(self)
+        # backingstore = self.backingStore()
+        # backingstore.beginPaint(rect2)
+        # painter = QtGui.QPainter(backingstore.paintDevice())
+
+        # We want to simply blit the image (copy pixels one-to-one on framebuffer).
+        # Maybe Qt does this when the sizes match exactly (like they do here).
+        # Converting to a QPixmap and painting that only makes it slower.
+
+        # Just in case, set render hints that may hurt performance.
+        painter.setRenderHints(
+            painter.RenderHint.Antialiasing | painter.RenderHint.SmoothPixmapTransform,
+            False,
+        )
+
+        image = QtGui.QImage(
+            image_data,
+            size[0],
+            size[1],
+            size[0] * 4,
+            QtGui.QImage.Format.Format_RGBA8888,
+        )
+
+        painter.drawImage(rect2, image, rect1)
+
+        # Uncomment for testing purposes
+        # painter.setPen(QtGui.QColor("#0000ff"))
+        # painter.setFont(QtGui.QFont("Arial", 30))
+        # painter.drawText(100, 100, "This is an image")
+
+        painter.end()
+        # backingstore.endPaint()
+        # backingstore.flush(rect2)
+
+    def _rc_get_physical_size(self):
         # https://doc.qt.io/qt-5/qpaintdevice.html
         # https://doc.qt.io/qt-5/highdpi.html
         lsize = self.width(), self.height()
@@ -268,7 +301,18 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         # integer then.
         return round(lsize[0] * ratio + 0.01), round(lsize[1] * ratio + 0.01)
 
-    def set_logical_size(self, width, height):
+    def _rc_get_logical_size(self):
+        # Sizes in Qt are logical
+        lsize = self.width(), self.height()
+        return float(lsize[0]), float(lsize[1])
+
+    def _rc_get_pixel_ratio(self):
+        # Observations:
+        # * On Win10 + PyQt5 the ratio is a whole number (175% becomes 2).
+        # * On Win10 + PyQt6 the ratio is correct (non-integer).
+        return self.devicePixelRatioF()
+
+    def _rc_set_logical_size(self, width, height):
         if width < 0 or height < 0:
             raise ValueError("Window width and height must not be negative")
         parent = self.parent()
@@ -277,20 +321,24 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         else:
             self.resize(width, height)  # See comment on pixel ratio
 
-    def _set_title(self, title):
+    def _rc_close(self):
+        parent = self.parent()
+        if isinstance(parent, QRenderCanvas):
+            QtWidgets.QWidget.close(parent)
+        else:
+            QtWidgets.QWidget.close(self)
+
+    def _rc_is_closed(self):
+        return self._is_closed
+
+    def _rc_set_title(self, title):
         # A QWidgets title can actually be shown when the widget is shown in a dock.
         # But the application should probably determine that title, not us.
         parent = self.parent()
         if isinstance(parent, QRenderCanvas):
             parent.setWindowTitle(title)
 
-    def close(self):
-        QtWidgets.QWidget.close(self)
-
-    def is_closed(self):
-        return self._is_closed
-
-    # User events to jupyter_rfb events
+    # %% Turn Qt events into rendercanvas events
 
     def _key_event(self, event_type, event):
         modifiers = tuple(
@@ -409,49 +457,8 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         self._is_closed = True
         self.submit_event({"event_type": "close"})
 
-    # Methods related to presentation of resulting image data
 
-    def present_image(self, image_data, **kwargs):
-        size = image_data.shape[1], image_data.shape[0]  # width, height
-        rect1 = QtCore.QRect(0, 0, size[0], size[1])
-        rect2 = self.rect()
-
-        painter = QtGui.QPainter(self)
-        # backingstore = self.backingStore()
-        # backingstore.beginPaint(rect2)
-        # painter = QtGui.QPainter(backingstore.paintDevice())
-
-        # We want to simply blit the image (copy pixels one-to-one on framebuffer).
-        # Maybe Qt does this when the sizes match exactly (like they do here).
-        # Converting to a QPixmap and painting that only makes it slower.
-
-        # Just in case, set render hints that may hurt performance.
-        painter.setRenderHints(
-            painter.RenderHint.Antialiasing | painter.RenderHint.SmoothPixmapTransform,
-            False,
-        )
-
-        image = QtGui.QImage(
-            image_data,
-            size[0],
-            size[1],
-            size[0] * 4,
-            QtGui.QImage.Format.Format_RGBA8888,
-        )
-
-        painter.drawImage(rect2, image, rect1)
-
-        # Uncomment for testing purposes
-        # painter.setPen(QtGui.QColor("#0000ff"))
-        # painter.setFont(QtGui.QFont("Arial", 30))
-        # painter.drawText(100, 100, "This is an image")
-
-        painter.end()
-        # backingstore.endPaint()
-        # backingstore.flush(rect2)
-
-
-class QRenderCanvas(BaseRenderCanvas, QtWidgets.QWidget):
+class QRenderCanvas(WrapperRenderCanvas, QtWidgets.QWidget):
     """A toplevel Qt widget providing a render canvas."""
 
     # Most of this is proxying stuff to the inner widget.
@@ -459,25 +466,17 @@ class QRenderCanvas(BaseRenderCanvas, QtWidgets.QWidget):
     # size can be set to subpixel (logical) values, without being able to
     # detect this. See https://github.com/pygfx/wgpu-py/pull/68
 
-    def __init__(self, *, size=None, title=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         # When using Qt, there needs to be an
         # application before any widget is created
         loop.init_qt()
+        super().__init__(*args, **kwargs)
 
-        sub_kwargs = pop_kwargs_for_base_canvas(kwargs)
-        super().__init__(**kwargs)
-
-        # Handle inputs
-        if title is None:
-            title = "qt canvas"
-        if not size:
-            size = 640, 480
+    def _rc_init(self, **canvas_kwargs):
+        self._subwidget = QRenderWidget(self, **canvas_kwargs)
 
         self.setAttribute(WA_DeleteOnClose, True)
         self.setMouseTracking(True)
-
-        self._subwidget = QRenderWidget(self, **sub_kwargs)
-        self._events = self._subwidget._events
 
         # Note: At some point we called `self._subwidget.winId()` here. For some
         # reason this was needed to "activate" the canvas. Otherwise the viz was
@@ -488,9 +487,6 @@ class QRenderCanvas(BaseRenderCanvas, QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
         layout.addWidget(self._subwidget)
-
-        self.set_logical_size(*size)
-        self.set_title(title)
         self.show()
 
     # Qt methods
@@ -500,56 +496,7 @@ class QRenderCanvas(BaseRenderCanvas, QtWidgets.QWidget):
         super().update()
 
     def closeEvent(self, event):  # noqa: N802
-        self._subwidget._is_closed = True
-        self.submit_event({"event_type": "close"})
-
-    # Methods that we add from BaseRenderCanvas (snake_case)
-
-    def _request_draw(self):
-        self._subwidget._request_draw()
-
-    def _force_draw(self):
-        self._subwidget._force_draw()
-
-    def _get_loop(self):
-        return None  # This means this outer widget won't have a scheduler
-
-    def get_present_info(self):
-        return self._subwidget.get_present_info()
-
-    def get_pixel_ratio(self):
-        return self._subwidget.get_pixel_ratio()
-
-    def get_logical_size(self):
-        return self._subwidget.get_logical_size()
-
-    def get_physical_size(self):
-        return self._subwidget.get_physical_size()
-
-    def set_logical_size(self, width, height):
-        if width < 0 or height < 0:
-            raise ValueError("Window width and height must not be negative")
-        self.resize(width, height)  # See comment on pixel ratio
-
-    def close(self):
-        QtWidgets.QWidget.close(self)
-
-    def is_closed(self):
-        return self._subwidget.is_closed()
-
-    # Methods that we need to explicitly delegate to the subwidget
-
-    def set_title(self, *args):
-        self._subwidget.set_title(*args)
-
-    def get_context(self, *args, **kwargs):
-        return self._subwidget.get_context(*args, **kwargs)
-
-    def request_draw(self, *args, **kwargs):
-        return self._subwidget.request_draw(*args, **kwargs)
-
-    def present_image(self, image, **kwargs):
-        return self._subwidget.present_image(image, **kwargs)
+        self._subwidget.closeEvent(event)
 
 
 # Make available under a name that is the same for all gui backends

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -472,9 +472,10 @@ class QRenderCanvas(WrapperRenderCanvas, QtWidgets.QWidget):
     # detect this. See https://github.com/pygfx/wgpu-py/pull/68
 
     def __init__(self, parent=None, **kwargs):
-        # When using Qt, there needs to be an
-        # application before any widget is created
+        # There needs to be an application before any widget is created.
         loop.init_qt()
+        # Any kwargs that we want to pass to *this* class, must be explicitly
+        # specified in the signature. The rest goes to the subwidget.
         super().__init__(parent)
 
         self._subwidget = QRenderWidget(self, **kwargs)

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -147,7 +147,9 @@ _show_image_method_warning = (
 class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
     """A QWidget representing a render canvas that can be embedded in a Qt application."""
 
-    def _rc_init(self, *, present_method, **_):
+    def __init__(self, *args, present_method=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
         # Determine present method
         self._surface_ids = None
         if not present_method:
@@ -174,6 +176,9 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         self.setAttribute(WA_InputMethodEnabled, True)
         self.setMouseTracking(True)
         self.setFocusPolicy(FocusPolicy.StrongFocus)
+
+        # Set size, title, etc.
+        self._final_canvas_init()
 
     def _get_surface_ids(self):
         if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
@@ -466,14 +471,13 @@ class QRenderCanvas(WrapperRenderCanvas, QtWidgets.QWidget):
     # size can be set to subpixel (logical) values, without being able to
     # detect this. See https://github.com/pygfx/wgpu-py/pull/68
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, parent=None, **kwargs):
         # When using Qt, there needs to be an
         # application before any widget is created
         loop.init_qt()
-        super().__init__(*args, **kwargs)
+        super().__init__(parent)
 
-    def _rc_init(self, **canvas_kwargs):
-        self._subwidget = QRenderWidget(self, **canvas_kwargs)
+        self._subwidget = QRenderWidget(self, **kwargs)
 
         self.setAttribute(WA_DeleteOnClose, True)
         self.setMouseTracking(True)
@@ -487,7 +491,9 @@ class QRenderCanvas(WrapperRenderCanvas, QtWidgets.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
         layout.addWidget(self._subwidget)
+
         self.show()
+        self._final_canvas_init()
 
     # Qt methods
 

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -128,7 +128,9 @@ _show_image_method_warning = (
 class WxRenderWidget(BaseRenderCanvas, wx.Window):
     """A wx Window representing a render canvas that can be embedded in a wx application."""
 
-    def _rc_init(self, present_method=None, **_):
+    def __init__(self, *args, present_method=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
         # Determine present method
         self._surface_ids = None
         if not present_method:
@@ -161,6 +163,7 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         self.Bind(wx.EVT_MOTION, self._on_mouse_move)
 
         self.Show()
+        self._final_canvas_init()
 
     def _on_resize_done(self, *args):
         self._draw_lock = False
@@ -425,14 +428,14 @@ class WxRenderCanvas(WrapperRenderCanvas, wx.Frame):
 
     # Most of this is proxying stuff to the inner widget.
 
-    def __init__(self, *, parent=None, **kwargs):
+    def __init__(self, parent=None, **kwargs):
         loop.init_wx()
-        super().__init__(parent, **kwargs)
+        super().__init__(parent)
 
-    def _rc_init(self, **canvas_kwargs):
-        self._subwidget = WxRenderWidget(parent=self, **canvas_kwargs)
+        self._subwidget = WxRenderWidget(parent=self, **kwargs)
         self.Bind(wx.EVT_CLOSE, lambda e: self.Destroy())
         self.Show()
+        self._final_canvas_init()
 
     # wx methods
 

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -429,11 +429,16 @@ class WxRenderCanvas(WrapperRenderCanvas, wx.Frame):
     # Most of this is proxying stuff to the inner widget.
 
     def __init__(self, parent=None, **kwargs):
+        # There needs to be an application before any widget is created.
         loop.init_wx()
+        # Any kwargs that we want to pass to *this* class, must be explicitly
+        # specified in the signature. The rest goes to the subwidget.
         super().__init__(parent)
 
         self._subwidget = WxRenderWidget(parent=self, **kwargs)
+
         self.Bind(wx.EVT_CLOSE, lambda e: self.Destroy())
+
         self.Show()
         self._final_canvas_init()
 

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -16,7 +16,12 @@ from ._gui_utils import (
     get_alt_x11_display,
     get_alt_wayland_display,
 )
-from .base import BaseRenderCanvas, BaseLoop, BaseTimer, pop_kwargs_for_base_canvas
+from .base import (
+    WrapperRenderCanvas,
+    BaseRenderCanvas,
+    BaseLoop,
+    BaseTimer,
+)
 
 
 BUTTON_MAP = {
@@ -123,9 +128,7 @@ _show_image_method_warning = (
 class WxRenderWidget(BaseRenderCanvas, wx.Window):
     """A wx Window representing a render canvas that can be embedded in a wx application."""
 
-    def __init__(self, *args, present_method=None, **kwargs):
-        super().__init__(*args, **kwargs)
-
+    def _rc_init(self, present_method=None, **_):
         # Determine present method
         self._surface_ids = None
         if not present_method:
@@ -157,10 +160,9 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         self.Bind(wx.EVT_MOUSE_EVENTS, self._on_mouse_events)
         self.Bind(wx.EVT_MOTION, self._on_mouse_move)
 
-        self.Show()
-
-    def _get_loop(self):
-        return loop
+    def _on_resize_done(self, *args):
+        self._draw_lock = False
+        self.Refresh()
 
     def on_paint(self, event):
         dc = wx.PaintDC(self)  # needed for wx
@@ -168,6 +170,109 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
             self._draw_frame_and_present()
         del dc
         event.Skip()
+
+    def _get_surface_ids(self):
+        if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
+            return {
+                "window": int(self.GetHandle()),
+            }
+        elif sys.platform.startswith("linux"):
+            if False:
+                # We fall back to XWayland, see _gui_utils.py
+                return {
+                    "platform": "wayland",
+                    "window": int(self.GetHandle()),
+                    "display": int(get_alt_wayland_display()),
+                }
+            else:
+                return {
+                    "platform": "x11",
+                    "window": int(self.GetHandle()),
+                    "display": int(get_alt_x11_display()),
+                }
+        else:
+            raise RuntimeError(f"Cannot get wx surface info on {sys.platform}.")
+
+    # %% Methods to implement RenderCanvas
+
+    def _rc_get_loop(self):
+        return loop
+
+    def _rc_get_present_info(self):
+        if self._surface_ids is None:
+            self._surface_ids = self._get_surface_ids()
+        global _show_image_method_warning
+        if self._present_to_screen and self._surface_ids:
+            info = {"method": "screen"}
+            info.update(self._surface_ids)
+        else:
+            if _show_image_method_warning:
+                logger.warn(_show_image_method_warning)
+                _show_image_method_warning = None
+            info = {
+                "method": "image",
+                "formats": ["rgba8unorm-srgb", "rgba8unorm"],
+            }
+        return info
+
+    def _rc_request_draw(self):
+        if self._draw_lock:
+            return
+        try:
+            self.Refresh()
+        except Exception:
+            pass  # avoid errors when window no longer lives
+
+    def _rc_force_draw(self):
+        self.Refresh()
+        self.Update()
+
+    def _rc_present_image(self, image_data, **kwargs):
+        size = image_data.shape[1], image_data.shape[0]  # width, height
+
+        dc = wx.PaintDC(self)
+        bitmap = wx.Bitmap.FromBufferRGBA(*size, image_data)
+        dc.DrawBitmap(bitmap, 0, 0, False)
+
+    def _rc_get_physical_size(self):
+        lsize = self.Size[0], self.Size[1]
+        lsize = float(lsize[0]), float(lsize[1])
+        ratio = self.GetContentScaleFactor()
+        return round(lsize[0] * ratio + 0.01), round(lsize[1] * ratio + 0.01)
+
+    def _rc_get_logical_size(self):
+        lsize = self.Size[0], self.Size[1]
+        return float(lsize[0]), float(lsize[1])
+
+    def _rc_get_pixel_ratio(self):
+        # todo: this is not hidpi-ready (at least on win10)
+        # Observations:
+        # * On Win10 this always returns 1 - so hidpi is effectively broken
+        return self.GetContentScaleFactor()
+
+    def _rc_set_logical_size(self, width, height):
+        if width < 0 or height < 0:
+            raise ValueError("Window width and height must not be negative")
+        parent = self.Parent
+        if isinstance(parent, WxRenderCanvas):
+            parent.SetSize(width, height)
+        else:
+            self.SetSize(width, height)
+
+    def _rc_close(self):
+        self._is_closed = True
+        self.Hide()
+
+    def _rc_is_closed(self):
+        return self._is_closed
+
+    def _rc_set_title(self, title):
+        # Set title only on frame
+        parent = self.Parent
+        if isinstance(parent, WxRenderCanvas):
+            parent.SetTitle(title)
+
+    # %% Turn Qt events into rendercanvas events
 
     def _on_resize(self, event: wx.SizeEvent):
         self._draw_lock = True
@@ -182,12 +287,6 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
             "pixel_ratio": self.get_pixel_ratio(),
         }
         self.submit_event(ev)
-
-    def _on_resize_done(self, *args):
-        self._draw_lock = False
-        self.Refresh()
-
-    # Methods for input events
 
     def _on_key_down(self, event: wx.KeyEvent):
         char_str = self._get_char_from_event(event)
@@ -310,204 +409,33 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
     def _on_mouse_move(self, event: wx.MouseEvent):
         self._mouse_event("pointer_move", event)
 
-    # Methods that we add from BaseRenderCanvas
 
-    def _get_surface_ids(self):
-        if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
-            return {
-                "window": int(self.GetHandle()),
-            }
-        elif sys.platform.startswith("linux"):
-            if False:
-                # We fall back to XWayland, see _gui_utils.py
-                return {
-                    "platform": "wayland",
-                    "window": int(self.GetHandle()),
-                    "display": int(get_alt_wayland_display()),
-                }
-            else:
-                return {
-                    "platform": "x11",
-                    "window": int(self.GetHandle()),
-                    "display": int(get_alt_x11_display()),
-                }
-        else:
-            raise RuntimeError(f"Cannot get wx surface info on {sys.platform}.")
-
-    def get_present_info(self):
-        if self._surface_ids is None:
-            self._surface_ids = self._get_surface_ids()
-        global _show_image_method_warning
-        if self._present_to_screen and self._surface_ids:
-            info = {"method": "screen"}
-            info.update(self._surface_ids)
-        else:
-            if _show_image_method_warning:
-                logger.warn(_show_image_method_warning)
-                _show_image_method_warning = None
-            info = {
-                "method": "image",
-                "formats": ["rgba8unorm-srgb", "rgba8unorm"],
-            }
-        return info
-
-    def get_pixel_ratio(self):
-        # todo: this is not hidpi-ready (at least on win10)
-        # Observations:
-        # * On Win10 this always returns 1 - so hidpi is effectively broken
-        return self.GetContentScaleFactor()
-
-    def get_logical_size(self):
-        lsize = self.Size[0], self.Size[1]
-        return float(lsize[0]), float(lsize[1])
-
-    def get_physical_size(self):
-        lsize = self.Size[0], self.Size[1]
-        lsize = float(lsize[0]), float(lsize[1])
-        ratio = self.GetContentScaleFactor()
-        return round(lsize[0] * ratio + 0.01), round(lsize[1] * ratio + 0.01)
-
-    def set_logical_size(self, width, height):
-        if width < 0 or height < 0:
-            raise ValueError("Window width and height must not be negative")
-        parent = self.Parent
-        if isinstance(parent, WxRenderCanvas):
-            parent.SetSize(width, height)
-        else:
-            self.SetSize(width, height)
-
-    def _set_title(self, title):
-        # Set title only on frame
-        parent = self.Parent
-        if isinstance(parent, WxRenderCanvas):
-            parent.SetTitle(title)
-
-    def _request_draw(self):
-        if self._draw_lock:
-            return
-        try:
-            self.Refresh()
-        except Exception:
-            pass  # avoid errors when window no longer lives
-
-    def _force_draw(self):
-        self.Refresh()
-        self.Update()
-
-    def close(self):
-        self._is_closed = True
-        self.Hide()
-
-    def is_closed(self):
-        return self._is_closed
-
-    @staticmethod
-    def _call_later(delay, callback, *args):
-        delay_ms = int(delay * 1000)
-        if delay_ms <= 0:
-            callback(*args)
-
-        wx.CallLater(max(delay_ms, 1), callback, *args)
-
-    def present_image(self, image_data, **kwargs):
-        size = image_data.shape[1], image_data.shape[0]  # width, height
-
-        dc = wx.PaintDC(self)
-        bitmap = wx.Bitmap.FromBufferRGBA(*size, image_data)
-        dc.DrawBitmap(bitmap, 0, 0, False)
-
-
-class WxRenderCanvas(BaseRenderCanvas, wx.Frame):
+class WxRenderCanvas(WrapperRenderCanvas, wx.Frame):
     """A toplevel wx Frame providing a render canvas."""
 
     # Most of this is proxying stuff to the inner widget.
 
-    def __init__(
-        self,
-        *,
-        parent=None,
-        size=None,
-        title=None,
-        **kwargs,
-    ):
+    def __init__(*args, **kwargs):
         loop.init_wx()
-        sub_kwargs = pop_kwargs_for_base_canvas(kwargs)
-        super().__init__(parent, **kwargs)
+        super().__init__(*args, **kwargs)
 
-        # Handle inputs
-        if title is None:
-            title = "wx canvas"
-        if not size:
-            size = 640, 480
+    def _rc_init(self, **canvas_kwargs):
+        self._subwidget = WxRenderWidget(parent=self, **canvas_kwargs)
 
-        self._subwidget = WxRenderWidget(parent=self, **sub_kwargs)
-        self._events = self._subwidget._events
         self.Bind(wx.EVT_CLOSE, lambda e: self.Destroy())
-
-        self.Show()
 
         # Force the canvas to be shown, so that it gets a valid handle.
         # Otherwise GetHandle() is initially 0, and getting a surface will fail.
+        self.Show()
         etime = time.perf_counter() + 1
         while self._subwidget.GetHandle() == 0 and time.perf_counter() < etime:
             loop.process_wx_events()
-
-        self.set_logical_size(*size)
-        self.set_title(title)
 
     # wx methods
 
     def Destroy(self):  # noqa: N802 - this is a wx method
         self._subwidget._is_closed = True
         super().Destroy()
-
-    # Methods that we add from wgpu
-    def _get_loop(self):
-        return None  # wrapper widget does not have scheduling
-
-    def get_present_info(self):
-        return self._subwidget.get_present_info()
-
-    def get_pixel_ratio(self):
-        return self._subwidget.get_pixel_ratio()
-
-    def get_logical_size(self):
-        return self._subwidget.get_logical_size()
-
-    def get_physical_size(self):
-        return self._subwidget.get_physical_size()
-
-    def set_logical_size(self, width, height):
-        if width < 0 or height < 0:
-            raise ValueError("Window width and height must not be negative")
-        self.SetSize(width, height)
-
-    def set_title(self, title):
-        self._subwiget.set_title(title)
-
-    def _request_draw(self):
-        return self._subwidget._request_draw()
-
-    def _force_draw(self):
-        return self._subwidget._force_draw()
-
-    def close(self):
-        self._subwidget._is_closed = True
-        super().Close()
-
-    def is_closed(self):
-        return self._subwidget._is_closed
-
-    # Methods that we need to explicitly delegate to the subwidget
-
-    def get_context(self, *args, **kwargs):
-        return self._subwidget.get_context(*args, **kwargs)
-
-    def request_draw(self, *args, **kwargs):
-        return self._subwidget.request_draw(*args, **kwargs)
-
-    def present_image(self, image, **kwargs):
-        return self._subwidget.present_image(image, **kwargs)
 
 
 # Make available under a name that is the same for all gui backends

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -46,8 +46,14 @@ class MyCanvas(BaseRenderCanvas):
         self.draw_count = 0
         self.events_count = 0
 
-    def _get_loop(self):
+    def _rc_get_loop(self):
         return self._loop
+
+    def _rc_close(self):
+        self._closed = True
+
+    def _rc_is_closed(self):
+        return self._closed
 
     def _process_events(self):
         super()._process_events()
@@ -57,7 +63,7 @@ class MyCanvas(BaseRenderCanvas):
         super()._draw_frame_and_present()
         self.draw_count += 1
 
-    def _request_draw(self):
+    def _rc_request_draw(self):
         self._gui_draw_requested = True
 
     def draw_if_necessary(self):
@@ -65,14 +71,8 @@ class MyCanvas(BaseRenderCanvas):
             self._gui_draw_requested = False
             self._draw_frame_and_present()
 
-    def close(self):
-        self._closed = True
-
-    def is_closed(self):
-        return self._closed
-
     def active_sleep(self, delay):
-        loop = self._get_loop()
+        loop = self._rc_get_loop()
         etime = time.perf_counter() + delay
         while time.perf_counter() < etime:
             time.sleep(0.001)


### PR DESCRIPTION
## Tasks

* [x] Refactors the initialization so implementing classes become simpler.
* [x] Use double-underscore where we can.
* [x] Prefix all methods that subclasses must implement with `_rc_`.
* [x] In the backends, put methods in a consistent order. 
* [x] Test for glfw
* [x] Test for qt
* [x] Test for offscreen
* [x] Test for wx
* [x] Test for jupyter   

## Decisions

Some notes on decisions I came to. I feel like the text below makes little sense for anyone else, since its all a bit hard to explain and the problems are rather subtle. Nevertheless, I think its good to have this on record.
 
### Init order

The initialization order is tricky. Taking qt as an example, the mro is:
 
* QObject
* ...
* QWidget
* BaseRenderCanvas
* QRenderWidget

All is good, except for one thing: I want `BaseRenderCanvas` to set the size and title (and maybe more in the future), because I don't want every subclass to have to bother with that. However, that must happen *after* the  QRenderWidget did its initialization. I played with some ideas, and implemented one where the the backend class (QRenderWidget) must implement `_rc_init` instead of `__init__`. But this is too weird. Thought of metaclasses, but that's too dark. Using `__new__` is also no help.

So I ended up with classic instantiation mechanics, and requiring backend canvas classes to call `_final_canvas_init()` to allow  `BaseRenderCanvas` to apply the final configuration (setting size, title, transparency etc.) A little anoying, but its explicit. And if the class author forgets to call it, you simply don't get the custom title and size set.

### Subwidget kwargs

Another tricky one, specific to the wrapper classes in qt and wx,  was how to pass the right kwargs to the real canvas (`._subwidget`). I previously had tricks like a function that popped canvas kwargs form the kwargs dict. In the end the solution is quite simple: any kwargs that the toplevel widget wants, must be explicitly taken, the rest is passed to the subwidget:

```py
class TopLevelClass(WrapperRenderCanvas, QWidget):
    def __init__(self, parent=None, **kwargs):
        super().__init__(parent)
        self._subwidget = QRenderWidget(self, **kwargs)
``` 