### PR TITLE
Add backends for all qt libs

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -40,16 +40,17 @@ but you can replace ``from rendercanvas.auto`` with ``from rendercanvas.glfw`` t
 Support for Qt
 --------------
 
-RenderCanvas has support for PyQt5, PyQt6, PySide2 and PySide6. It detects what
-qt library you are using by looking what module has been imported.
+RenderCanvas has support for PyQt5, PyQt6, PySide2 and PySide6.
 For a toplevel widget, the ``rendercanvas.qt.RenderCanvas`` class can be imported. If you want to
 embed the canvas as a subwidget, use ``rendercanvas.qt.QRenderWidget`` instead.
 
+Importing ``rendercanvas.qt`` detects what qt library is currently imported:
+
 .. code-block:: py
 
-    # Import any of the Qt libraries before importing the RenderCanvas.
-    # This way rendercanvas knows which Qt library to use.
+    # Import Qt first, otherwise rendercanvas does not know what qt-lib to use
     from PySide6 import QtWidgets
+
     from rendercanvas.qt import RenderCanvas  # use this for top-level windows
     from rendercanvas.qt import QRenderWidget  # use this for widgets in you application
 
@@ -62,6 +63,21 @@ embed the canvas as a subwidget, use ``rendercanvas.qt.QRenderWidget`` instead.
     canvas.request_draw(your_draw_function)
 
     app.exec_()
+
+
+Alternatively, you can select the specific qt library to use, making it easy to e.g. test an example on a specific Qt library.
+
+.. code-block:: py
+
+    from rendercanvas.pyside6 import RenderCanvas, loop
+
+    # Instantiate the canvas
+    canvas = RenderCanvas(title="Example")
+
+    # Tell the canvas what drawing function to call
+    canvas.request_draw(your_draw_function)
+
+    loop.run()  # calls app.exec_()
 
 
 Support for wx

--- a/rendercanvas/pyqt5.py
+++ b/rendercanvas/pyqt5.py
@@ -1,0 +1,11 @@
+# ruff: noqa: E402, F403
+
+import os
+
+ref_libname = "PyQt5"
+os.environ["_RENDERCANVAS_QT_LIB"] = ref_libname
+
+from .qt import check_qt_libname
+from .qt import *
+
+check_qt_libname(ref_libname)

--- a/rendercanvas/pyqt6.py
+++ b/rendercanvas/pyqt6.py
@@ -1,0 +1,11 @@
+# ruff: noqa: E402, F403
+
+import os
+
+ref_libname = "PyQt6"
+os.environ["_RENDERCANVAS_QT_LIB"] = ref_libname
+
+from .qt import check_qt_libname
+from .qt import *
+
+check_qt_libname(ref_libname)

--- a/rendercanvas/pyside2.py
+++ b/rendercanvas/pyside2.py
@@ -1,0 +1,11 @@
+# ruff: noqa: E402, F403
+
+import os
+
+ref_libname = "PySide2"
+os.environ["_RENDERCANVAS_QT_LIB"] = ref_libname
+
+from .qt import check_qt_libname
+from .qt import *
+
+check_qt_libname(ref_libname)

--- a/rendercanvas/pyside6.py
+++ b/rendercanvas/pyside6.py
@@ -1,0 +1,11 @@
+# ruff: noqa: E402, F403
+
+import os
+
+ref_libname = "PySide6"
+os.environ["_RENDERCANVAS_QT_LIB"] = ref_libname
+
+from .qt import check_qt_libname
+from .qt import *
+
+check_qt_libname(ref_libname)


### PR DESCRIPTION
* [x] Adds shims so one can do `from rendercanvas.pyside6 import RenderCanvas, loop`.
* [x] Fix a few problems with PyQt6 😅 
* [x] Document this.  

When selecting the qt backend via these modules, it can be that `rendercanvas.qt` has already been imported with another qt-lib. That's why we also do a check to make sure it's actually the intended lib being used.