### PR TITLE
Dont stop asyncio loop when interactive

### DIFF
--- a/rendercanvas/asyncio.py
+++ b/rendercanvas/asyncio.py
@@ -40,7 +40,7 @@ class AsyncioTimer(BaseTimer):
 class AsyncioLoop(BaseLoop):
     _TimerClass = AsyncioTimer
     _the_loop = None
-    _is_interactive = False
+    _is_interactive = True  # When run() is not called, assume interactive
 
     @property
     def _loop(self):
@@ -73,6 +73,7 @@ class AsyncioLoop(BaseLoop):
     def _rc_stop(self):
         if not self._is_interactive:
             self._loop.stop()
+            self._is_interactive = True
 
     def _rc_call_soon(self, callback, *args):
         self._loop.call_soon(callback, *args)


### PR DESCRIPTION
When `loop.run()` was not called, but the canvas is still running, e.g. because in an interactive env, then when the canvas was closed, the interactive loop was stopped. This prevents that.