### PR TITLE
Handle ctrl-c

### DIFF
--- a/rendercanvas/_loop.py
+++ b/rendercanvas/_loop.py
@@ -17,8 +17,6 @@ HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
-# if sys.platform == "win32":
-#     HANDLED_SIGNALS += (signal.SIGBREAK,)  # Windows signal 21. Sent by Ctrl+Break.
 
 
 class BaseTimer:

--- a/rendercanvas/asyncio.py
+++ b/rendercanvas/asyncio.py
@@ -40,7 +40,6 @@ class AsyncioTimer(BaseTimer):
 class AsyncioLoop(BaseLoop):
     _TimerClass = AsyncioTimer
     _the_loop = None
-    _is_interactive = True  # When run() is not called, assume interactive
 
     @property
     def _loop(self):
@@ -58,16 +57,12 @@ class AsyncioLoop(BaseLoop):
         return loop
 
     def _rc_run(self):
-        if self._loop.is_running():
-            self._is_interactive = True
-        else:
-            self._is_interactive = False
+        if not self._loop.is_running():
             self._loop.run_forever()
 
     def _rc_stop(self):
-        if not self._is_interactive:
-            self._loop.stop()
-            self._is_interactive = True
+        # Note: is only called when we're inside _rc_run
+        self._loop.stop()
 
     def _rc_call_soon(self, callback, *args):
         self._loop.call_soon(callback, *args)

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -116,9 +116,9 @@ class BaseRenderCanvas:
             self.set_title(kwargs["title"])
 
     def __del__(self):
-        # On delete, we call the custom close method.
+        # On delete, we call the custom destroy method.
         try:
-            self.close()
+            self._rc_close()
         except Exception:
             pass
         # Since this is sometimes used in a multiple inheritance, the
@@ -497,9 +497,6 @@ class BaseRenderCanvas:
     def _rc_close(self):
         """Close the canvas.
 
-        For widgets that are wrapped by a ``WrapperRenderCanvas``, this should probably
-        close the wrapper instead.
-
         Note that ``BaseRenderCanvas`` implements the ``close()`` method, which
         is a rather common name; it may be necessary to re-implement that too.
         """
@@ -511,9 +508,6 @@ class BaseRenderCanvas:
 
     def _rc_set_title(self, title):
         """Set the canvas title. May be ignored when it makes no sense.
-
-        For widgets that are wrapped by a ``WrapperRenderCanvas``, this should probably
-        set the title of the wrapper instead.
 
         The default implementation does nothing.
         """

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -577,8 +577,8 @@ class QtLoop(BaseLoop):
         app.exec() if hasattr(app, "exec") else app.exec_()
 
     def _rc_stop(self):
-        if not already_had_app_on_import:
-            self._app.quit()
+        # Note: is only called when we're inside _rc_run
+        self._app.quit()
 
     def _rc_gui_poll(self):
         pass  # we assume the Qt event loop is running. Calling processEvents() will cause recursive repaints.

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -500,11 +500,16 @@ class WxLoop(BaseLoop):
 
     def _rc_run(self):
         self._frame_to_keep_loop_alive = wx.Frame(None)
-        self._app.MainLoop()
+        try:
+            self._app.MainLoop()
+        finally:
+            self._rc_stop()
 
     def _rc_stop(self):
-        self._frame_to_keep_loop_alive.Destroy()
-        _frame_to_keep_loop_alive = None
+        # Stop the loop by closing the last frame
+        if self._frame_to_keep_loop_alive:
+            self._frame_to_keep_loop_alive.Destroy()
+            self._frame_to_keep_loop_alive = None
 
     def _rc_gui_poll(self):
         pass  # We can assume the wx loop is running.

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -482,7 +482,6 @@ class WxTimer(BaseTimer):
 class WxLoop(BaseLoop):
     _TimerClass = WxTimer
     _the_app = None
-    _frame_to_keep_loop_alive = None
 
     def init_wx(self):
         _ = self._app
@@ -499,17 +498,13 @@ class WxLoop(BaseLoop):
         wx.CallSoon(callback, args)
 
     def _rc_run(self):
-        self._frame_to_keep_loop_alive = wx.Frame(None)
-        try:
-            self._app.MainLoop()
-        finally:
-            self._rc_stop()
+        self._app.MainLoop()
 
     def _rc_stop(self):
-        # Stop the loop by closing the last frame
-        if self._frame_to_keep_loop_alive:
-            self._frame_to_keep_loop_alive.Destroy()
-            self._frame_to_keep_loop_alive = None
+        # It looks like we cannot make wx stop the loop.
+        # In general not a problem, because the BaseLoop will try
+        # to close all windows before stopping a loop.
+        pass
 
     def _rc_gui_poll(self):
         pass  # We can assume the wx loop is running.

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,29 @@
+"""
+Some tests for the base loop and asyncio loop.
+"""
+
+import threading
+
+from rendercanvas.asyncio import AsyncioLoop
+from testutils import run_tests
+
+
+def run_loop_briefly():
+    loop = AsyncioLoop()
+    loop.call_later(0.1, print, "hi from loop!")
+    loop.call_later(0.2, loop.stop)
+    loop.run()
+
+
+def test_loop_main():
+    run_loop_briefly()
+
+
+def test_loop_threaded():
+    t = threading.Thread(target=run_loop_briefly)
+    t.start()
+    t.join()
+
+
+if __name__ == "__main__":
+    run_tests(globals())

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2,25 +2,146 @@
 Some tests for the base loop and asyncio loop.
 """
 
+import time
+import signal
 import threading
 
 from rendercanvas.asyncio import AsyncioLoop
 from testutils import run_tests
 
 
-def run_loop_briefly():
+class FakeCanvas:
+    def __init__(self, refuse_close):
+        self.refuse_close = refuse_close
+        self.is_closed = False
+
+    def _rc_close(self):
+        # Called by the loop to close a canvas
+        if not self.refuse_close:
+            self.is_closed = True
+
+
+class FakeScheduler:
+    def __init__(self, refuse_close=False):
+        self._canvas = FakeCanvas(refuse_close)
+
+    def get_canvas(self):
+        if self._canvas and not self._canvas.is_closed:
+            return self._canvas
+
+    def close_canvas(self):
+        self._canvas = None
+
+
+def test_run_loop_and_close_bc_no_canvases():
+    # Run the loop without canvas; closes immediately
     loop = AsyncioLoop()
     loop.call_later(0.1, print, "hi from loop!")
-    loop.call_later(0.2, loop.stop)
     loop.run()
 
 
-def test_loop_main():
-    run_loop_briefly()
+def test_run_loop_and_close_canvases():
+    # After all canvases are closed, it can take one tick before its detected.
+
+    loop = AsyncioLoop()
+
+    scheduler1 = FakeScheduler()
+    scheduler2 = FakeScheduler()
+    loop._register_scheduler(scheduler1)
+    loop._register_scheduler(scheduler2)
+
+    loop.call_later(0.1, print, "hi from loop!")
+    loop.call_later(0.1, scheduler1.close_canvas)
+    loop.call_later(0.3, scheduler2.close_canvas)
+
+    t0 = time.time()
+    loop.run()
+    et = time.time() - t0
+
+    print(et)
+    assert 0.25 < et < 0.45
+
+
+def test_run_loop_and_close_with_method():
+    # Close, then wait at most one tick to close canvases, and another to conform close.
+    loop = AsyncioLoop()
+
+    scheduler1 = FakeScheduler()
+    scheduler2 = FakeScheduler()
+    loop._register_scheduler(scheduler1)
+    loop._register_scheduler(scheduler2)
+
+    loop.call_later(0.1, print, "hi from loop!")
+    loop.call_later(0.3, loop.stop)
+
+    t0 = time.time()
+    loop.run()
+    et = time.time() - t0
+
+    print(et)
+    assert 0.25 < et < 0.55
+
+
+def test_run_loop_and_interrupt():
+    # Interrupt, calls close, can take one tick to close canvases, and anoter to conform close.
+
+    loop = AsyncioLoop()
+
+    scheduler1 = FakeScheduler()
+    scheduler2 = FakeScheduler()
+    loop._register_scheduler(scheduler1)
+    loop._register_scheduler(scheduler2)
+
+    loop.call_later(0.1, print, "hi from loop!")
+
+    def interrupt_soon():
+        time.sleep(0.3)
+        signal.raise_signal(signal.SIGINT)
+
+    t = threading.Thread(target=interrupt_soon)
+    t.start()
+
+    t0 = time.time()
+    loop.run()
+    et = time.time() - t0
+    t.join()
+
+    print(et)
+    assert 0.25 < et < 0.55
+
+
+def test_run_loop_and_interrupt_harder():
+    # In the next tick after the second interupt, it stops the loop without closing the canvases
+
+    loop = AsyncioLoop()
+
+    scheduler1 = FakeScheduler(refuse_close=True)
+    scheduler2 = FakeScheduler(refuse_close=True)
+    loop._register_scheduler(scheduler1)
+    loop._register_scheduler(scheduler2)
+
+    loop.call_later(0.1, print, "hi from loop!")
+
+    def interrupt_soon():
+        time.sleep(0.3)
+        signal.raise_signal(signal.SIGINT)
+        time.sleep(0.3)
+        signal.raise_signal(signal.SIGINT)
+
+    t = threading.Thread(target=interrupt_soon)
+    t.start()
+
+    t0 = time.time()
+    loop.run()
+    et = time.time() - t0
+    t.join()
+
+    print(et)
+    assert 0.6 < et < 0.75
 
 
 def test_loop_threaded():
-    t = threading.Thread(target=run_loop_briefly)
+    t = threading.Thread(target=test_run_loop_and_close_with_method)
     t.start()
     t.join()
 


### PR DESCRIPTION
See https://github.com/pygfx/pygfx/issues/377

Inspired mostly by https://github.com/encode/uvicorn/blob/master/uvicorn/server.py

Sending sigint will stop the event loop, if we're the one running it. These changes improve the behavior of the base loop implementation, so that the subclasses can actually be made quite a bit simpler.

* [x] Tested on MacOS 
* [x] Tested on Windows
* [x] Tested on Linux