### PR TITLE
Rename is_closed() to get_closed()

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -51,7 +51,7 @@ def process_event(event):
         # Should see this exactly once, either when pressing escape, or
         # when pressing the window close button.
         print("Close detected!")
-        assert canvas.is_closed()
+        assert canvas.get_closed()
 
 
 if __name__ == "__main__":

--- a/examples/offsceen_threaded.py
+++ b/examples/offsceen_threaded.py
@@ -34,7 +34,7 @@ def main():
     frame_count = 0
     canvas.request_draw(draw_frame)
 
-    while not canvas.is_closed():
+    while not canvas.get_closed():
         image = canvas.draw()
         frame_count += 1
         print(f"Rendered {frame_count} frames, last shape is {image.shape}")

--- a/rendercanvas/_loop.py
+++ b/rendercanvas/_loop.py
@@ -451,7 +451,7 @@ class Scheduler:
     def get_canvas(self):
         """Get the canvas, or None if it is closed or gone."""
         canvas = self._canvas_ref()
-        if canvas is None or canvas.is_closed():
+        if canvas is None or canvas.get_closed():
             # Pretty nice, we can send a close event, even if the canvas no longer exists
             self._events._rc_close()
             return None

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -8,7 +8,7 @@ import importlib
 
 from ._events import EventEmitter, EventType  # noqa: F401
 from ._loop import Scheduler, BaseLoop, BaseTimer
-from ._coreutils import log_exception
+from ._coreutils import logger, log_exception
 
 
 # Notes on naming and prefixes:
@@ -327,7 +327,7 @@ class BaseRenderCanvas:
             # "draw event" that we requested, or as part of a forced draw.
 
             # Cannot draw to a closed canvas.
-            if self._rc_is_closed():
+            if self._rc_get_closed():
                 return
 
             # Process special events
@@ -382,9 +382,15 @@ class BaseRenderCanvas:
         """Close the canvas."""
         self._rc_close()
 
-    def is_closed(self):
+    def get_closed(self):
         """Get whether the window is closed."""
-        return self._rc_is_closed()
+        return self._rc_get_closed()
+
+    def is_closed(self):
+        logger.warning(
+            "canvas.is_closed() is deprecated, use canvas.get_closed() instead."
+        )
+        return self._rc_get_closed()
 
     # %% Secondary canvas management methods
 
@@ -502,7 +508,7 @@ class BaseRenderCanvas:
         """
         pass
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         """Get whether the canvas is closed."""
         return False
 
@@ -557,6 +563,9 @@ class WrapperRenderCanvas(BaseRenderCanvas):
 
     def close(self):
         self._subwidget.close()
+
+    def get_closed(self):
+        return self._subwidget.get_closed()
 
     def is_closed(self):
         return self._subwidget.is_closed()

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -319,7 +319,7 @@ class GlfwRenderCanvas(BaseRenderCanvas):
             self._window = None
             self.submit_event({"event_type": "close"})
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         return self._window is None
 
     def _rc_set_title(self, title):

--- a/rendercanvas/jupyter.py
+++ b/rendercanvas/jupyter.py
@@ -105,7 +105,7 @@ class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
     def _rc_close(self):
         RemoteFrameBuffer.close(self)
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         return self._is_closed
 
     def _rc_set_title(self, title):
@@ -142,7 +142,7 @@ class JupyterAsyncioLoop(AsyncioLoop):
         canvases = [r() for r in self._pending_jupyter_canvases]
         self._pending_jupyter_canvases.clear()
         for w in canvases:
-            if w and not w.is_closed():
+            if w and not w.get_closed():
                 display(w)
 
 

--- a/rendercanvas/offscreen.py
+++ b/rendercanvas/offscreen.py
@@ -60,7 +60,7 @@ class ManualOffscreenRenderCanvas(BaseRenderCanvas):
     def _rc_close(self):
         self._closed = True
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         return self._closed
 
     def _rc_set_title(self, title):

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -343,7 +343,7 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         else:
             QtWidgets.QWidget.close(self)
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         return self._is_closed
 
     def _rc_set_title(self, title):

--- a/rendercanvas/stub.py
+++ b/rendercanvas/stub.py
@@ -58,7 +58,7 @@ class StubRenderCanvas(BaseRenderCanvas):
     def _rc_close(self):
         pass
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         return False
 
     def _rc_set_title(self, title):

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -278,7 +278,7 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         else:
             self.Hide()
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         return self._is_closed
 
     def _rc_set_title(self, title):

--- a/tests/test_glfw.py
+++ b/tests/test_glfw.py
@@ -58,10 +58,10 @@ def test_glfw_canvas_basics():
     assert isinstance(canvas.get_pixel_ratio(), float)
 
     # Close
-    assert not canvas.is_closed()
+    assert not canvas.get_closed()
     canvas.close()
     glfw.poll_events()
-    assert canvas.is_closed()
+    assert canvas.get_closed()
 
 
 def test_glfw_canvas_del():

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -52,7 +52,7 @@ class MyCanvas(BaseRenderCanvas):
     def _rc_close(self):
         self._closed = True
 
-    def _rc_is_closed(self):
+    def _rc_get_closed(self):
         return self._closed
 
     def _process_events(self):


### PR DESCRIPTION
All public methods on canvas are verbs, except `canvas.is_closed()`. The name looks like its a property, but its a method. It does not help that we have `timer.is_running` and `timer.is_one_shot` properties.

This PR renames it to `get_closed()`, the old method is still supported, but with a warning.