### PR TITLE
Remove run function

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -241,4 +241,4 @@ glfw if asyncio is enabled or Qt if a qt app is running.
 On an interactive session without GUI support, one must call ``loop.run()`` to make
 the canvases interactive. This enters the main loop, which prevents entering new
 code. Once all canvases are closed, the loop returns. If you make new canvases
-afterwards, you can call ``run()`` again. This is similar to ``plt.show()`` in Matplotlib.
+afterwards, you can call ``loop.run()`` again. This is similar to ``plt.show()`` in Matplotlib.

--- a/examples/cube_qt.py
+++ b/examples/cube_qt.py
@@ -21,7 +21,7 @@ for lib in ("PySide6", "PyQt6", "PySide2", "PyQt5"):
         pass
 
 
-from rendercanvas.qt import RenderCanvas, run
+from rendercanvas.qt import RenderCanvas, loop
 from rendercanvas.utils.cube import setup_drawing_sync
 
 
@@ -31,4 +31,4 @@ canvas.request_draw(draw_frame)
 
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/events.py
+++ b/examples/events.py
@@ -5,7 +5,7 @@ Events
 A simple example to demonstrate events.
 """
 
-from rendercanvas.auto import RenderCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 
 canvas = RenderCanvas(title="RenderCanvas events")
@@ -18,4 +18,4 @@ def process_event(event):
 
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/rendercanvas/auto.py
+++ b/rendercanvas/auto.py
@@ -203,4 +203,3 @@ def backends_by_trying_in_order():
 module = select_backend()
 RenderCanvas = module.RenderCanvas
 loop = module.loop
-run = loop.run  # backwards compat

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -563,4 +563,3 @@ def poll_glfw_briefly(poll_time=0.1):
 # Make available under a name that is the same for all backends
 loop = loop  # default loop is AsyncioLoop
 RenderCanvas = GlfwRenderCanvas
-run = loop.run()  # backwards compat

--- a/rendercanvas/jupyter.py
+++ b/rendercanvas/jupyter.py
@@ -120,4 +120,3 @@ class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
 # Make available under a name that is the same for all backends
 RenderCanvas = JupyterRenderCanvas
 loop = loop
-run = loop.run

--- a/rendercanvas/offscreen.py
+++ b/rendercanvas/offscreen.py
@@ -140,4 +140,3 @@ class StubLoop(BaseLoop):
 
 
 loop = StubLoop()
-run = loop.run

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -585,4 +585,3 @@ class QRenderCanvas(WrapperRenderCanvas, QtWidgets.QWidget):
 # Make available under a name that is the same for all gui backends
 RenderWidget = QRenderWidget
 RenderCanvas = QRenderCanvas
-run = loop.run  # backwards compat

--- a/rendercanvas/stub.py
+++ b/rendercanvas/stub.py
@@ -133,4 +133,3 @@ class ToplevelRenderCanvas(WrapperRenderCanvas):
 # Make available under a common name
 RenderCanvas = StubRenderCanvas
 loop = StubLoop()
-run = loop.run

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -525,4 +525,3 @@ class WxRenderCanvas(WrapperRenderCanvas, wx.Frame):
 # Make available under a name that is the same for all gui backends
 RenderWidget = WxRenderWidget
 RenderCanvas = WxRenderCanvas
-run = loop.run  # backwards compat

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -114,7 +114,6 @@ class Module:
 
     def get_loop_class(self):
         assert "loop" in self.names
-        assert "run" in self.names
 
         loop_statement = self.names["loop"]
         assert isinstance(loop_statement, ast.Assign)
@@ -188,7 +187,6 @@ def test_auto_module():
     m = Module("auto")
     assert "RenderCanvas" in m.names
     assert "loop" in m.names
-    assert "run" in m.names
 
 
 # %% Test modules that only provide a loop


### PR DESCRIPTION
Use `loop.run()`  instead. I left it for backwards compat, but with loops being able to drive canvases of different backends, this just add confusion.