### PR TITLE
Fix rendering via bitmap adapter

### DIFF
--- a/examples/noise.py
+++ b/examples/noise.py
@@ -8,7 +8,7 @@ Simple example that uses the bitmap-context to show images of noise.
 # run_example = true
 
 import numpy as np
-from rendercanvas.pyside6 import RenderCanvas, loop
+from rendercanvas.auto import RenderCanvas, loop
 
 
 canvas = RenderCanvas(update_mode="continuous")

--- a/examples/noise.py
+++ b/examples/noise.py
@@ -8,7 +8,7 @@ Simple example that uses the bitmap-context to show images of noise.
 # run_example = true
 
 import numpy as np
-from rendercanvas.auto import RenderCanvas, loop
+from rendercanvas.pyside6 import RenderCanvas, loop
 
 
 canvas = RenderCanvas(update_mode="continuous")

--- a/rendercanvas/utils/bitmappresentadapter.py
+++ b/rendercanvas/utils/bitmappresentadapter.py
@@ -36,7 +36,8 @@ class BitmapPresentAdapter:
         self._texture_helper.set_texture_data(bitmap)
 
         if not self._context_is_configured:
-            self._context.configure(device=self._device, format="rgba8unorm")
+            format = self._context.get_preferred_format(self._device.adapter)
+            self._context.configure(device=self._device, format=format)
 
         target = self._context.get_current_texture().create_view()
         command_encoder = self._device.create_command_encoder()


### PR DESCRIPTION
For some reason the bitmap example stopped working for me. Not sure why, but is better practice to use the preferred format anyway.