### PR TITLE
fix set logical size in `JupyterRenderCanvas`

### DIFF
--- a/rendercanvas/jupyter.py
+++ b/rendercanvas/jupyter.py
@@ -92,6 +92,7 @@ class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
         return self._pixel_ratio
 
     def _rc_set_logical_size(self, width, height):
+        self._logical_size = width, height
         self.css_width = f"{width}px"
         self.css_height = f"{height}px"
 


### PR DESCRIPTION
The initial logical size for `JupyterRenderCanvas` is (0, 0) by default which causes sporadic divide by zero errors with WGPU validation and also creates issues for CI since `get_frame()` returns blank screenshots and then improperly sized screenshots before returning correct screenshots (I'm guessing until it processes events to resize the canvas?). This changes it so that if a size is specified for the canvas in the constructor, then that size is used for the logical_size in addition to the css width and height. Not sure if we should just change the default size in the constructor from (0, 0) as well.
