### PR TITLE
Dont get winId in qt and wx with bitmap present-method

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -185,6 +185,17 @@ But the other way around, running a Qt canvas in e.g. the trio loop, works fine:
     trio.run(loop.run_async)
 
 
+There are known issue with Qt widgets that render directly to screen (i.e. widgets that obtain ``widget.winId()``),
+related to how they interact with other widgets and in docks.
+If you encounter such issues, consider using the bitmap present-method. That way, the rendering happens
+off-screen, and is than provided to Qt as an image. This is a safer approach, albeit lowers the performance (FPS)
+somewhat when the render area is large.
+
+.. code-block:: py
+
+    widget = QRenderWidget(present_method="bitmap")
+
+
 Support for wx
 --------------
 

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -242,7 +242,6 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
 
         self._is_closed = False
 
-        self.setAttribute(WA_PaintOnScreen, self._present_to_screen)
         self.setAutoFillBackground(False)
         self.setAttribute(WA_DeleteOnClose, True)
         self.setAttribute(WA_InputMethodEnabled, True)
@@ -314,6 +313,8 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         methods = {}
         if self._present_to_screen:
             methods["screen"] = self._surface_ids
+            # Now is a good time to set WA_PaintOnScreen. Note that it implies WA_NativeWindow.
+            self.setAttribute(WA_PaintOnScreen, self._present_to_screen)
         else:
             if _show_image_method_warning:
                 logger.warning(_show_image_method_warning)

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -272,7 +272,8 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
                     "display": int(get_alt_x11_display()),
                 }
         else:
-            raise RuntimeError(f"Cannot get Qt surface info on {sys.platform}.")
+            logger.warning(f"Cannot get Qt surface info on {sys.platform}.")
+            return None
 
     # %% Qt methods
 
@@ -304,8 +305,11 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
 
     def _rc_get_present_methods(self):
         global _show_image_method_warning
-        if self._surface_ids is None:
+
+        if self._present_to_screen and self._surface_ids is None:
             self._surface_ids = self._get_surface_ids()
+            if self._surface_ids is None:
+                self._present_to_screen = False
 
         methods = {}
         if self._present_to_screen:


### PR DESCRIPTION
Ref #55

Even calling `winId()` causes issues for Qt widgets. So let's not do it unless we need that id.