### PR TITLE
Initial size of glfw windows

### DIFF
--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -181,8 +181,13 @@ class GlfwRenderCanvas(BaseRenderCanvas):
         glfw.window_hint(glfw.CLIENT_API, glfw.NO_API)
         glfw.window_hint(glfw.RESIZABLE, True)
 
+        if "size" in kwargs.keys():
+            w, h = kwargs["size"]
+        else:
+            w, h = 640, 480
+
         # Create the window (the initial size may not be in logical pixels)
-        self._window = glfw.create_window(640, 480, "", None, None)
+        self._window = glfw.create_window(w, h, "", None, None)
 
         # Other internal variables
         self._changing_pixel_ratio = False


### PR DESCRIPTION
Not sure if this is a good fix but made the PR to get thoughts! The initial canvas size in Qt and jupyter are the same as what is given by the `size` kwarg, but the `glfw` canvas does not use this for the initial size (it appears to resize aftewards?). This is an issue for [creating layouts that are based on the inital canvas size](https://github.com/fastplotlib/fastplotlib/pull/740#issuecomment-2721872300), not sure if this is the best fix.
