### PR TITLE
hide bitmap warning when explicitly picked

### DIFF
--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -238,6 +238,9 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         elif present_method == "screen":
             self._present_to_screen = True
         elif present_method == "bitmap":
+            global _show_image_method_warning
+
+            _show_image_method_warning = None
             self._present_to_screen = False
         else:
             raise ValueError(f"Invalid present_method {present_method}")

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -202,6 +202,9 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         elif present_method == "screen":
             self._present_to_screen = True
         elif present_method == "bitmap":
+            global _show_image_method_warning
+
+            _show_image_method_warning = None
             self._present_to_screen = False
         else:
             raise ValueError(f"Invalid present_method {present_method}")


### PR DESCRIPTION
Thank you for the ability to use bitmap without calling `winId()` @almarklein, I think it might be working well for me just "as is". 👍 

this PR suppresses the `rendercanvas:Qt falling back to offscreen rendering, which is less performant` warning when bitmap was explicitly selected (not really a fallback at that rate)

*edit*:

> I think it might be working well for me just "as is"

maybe not actually, I am seeing a noticeable difference.  will continue to tinker 