### PR TITLE
Fix AttributeError on present() "fail" case

### DIFF
--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -417,7 +417,7 @@ class BaseRenderCanvas:
                     if method in ("skip", "screen"):
                         pass  # nothing we need to do
                     elif method == "fail":
-                        raise RuntimeError(method.get("message", "") or "present error")
+                        raise RuntimeError(result.get("message", "") or "present error")
                     else:
                         # Pass the result to the literal present method
                         func = getattr(self, f"_rc_present_{method}")


### PR DESCRIPTION
When the context returns a failure message, the exception handling logic tries to "get" a field from the message string instead of the result dict, causing the error not to be displayed correctly:

`AttributeError: 'str' object has no attribute 'get'`