### PR TITLE
Better canvas cleanup, avoids segfaults on some systems with glfw+wgpu

### DIFF
--- a/rendercanvas/_context.py
+++ b/rendercanvas/_context.py
@@ -76,3 +76,7 @@ class ContextInterface:
 
         # This is a stub
         return {"method": "skip"}
+
+    def _release(self):
+        """Release resources. Called by the canvas when it's closed."""
+        pass

--- a/rendercanvas/_events.py
+++ b/rendercanvas/_events.py
@@ -66,7 +66,7 @@ class EventEmitter:
         self._event_handlers = defaultdict(list)
         self._closed = False
 
-    def _set_closed(self):
+    def _release(self):
         self._closed = True
         self._pending_events.clear()
         self._event_handlers.clear()
@@ -222,7 +222,7 @@ class EventEmitter:
                     callback(event)
         # Close?
         if event_type == "close":
-            self._set_closed()
+            self._release()
 
     async def close(self):
         """Close the event handler.

--- a/rendercanvas/_loop.py
+++ b/rendercanvas/_loop.py
@@ -133,7 +133,7 @@ class BaseLoop:
                     for canvas in self.get_canvases():
                         if not getattr(canvas, "_rc_closed_by_loop", False):
                             canvas._rc_closed_by_loop = True
-                            canvas._rc_close()
+                            canvas.close()
                         del canvas
 
         finally:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -44,7 +44,7 @@ class FakeCanvas:
     def _rc_gui_poll(self):
         pass
 
-    def _rc_close(self):
+    def close(self):
         # Called by the loop to close a canvas
         if not self.refuse_close:
             self.is_closed = True


### PR DESCRIPTION
Ref https://github.com/pygfx/pygfx/issues/642

* [x] Replace calls to `._rc_close() with `.close()`
* [x] In `close()` do additional cleanup for the canvas, because these can hold onto (wgpu) resources:
  * The draw function.
  * The canvas context.
  * The event handlers (sanity check; likely already happened).
* [x] Delay glfw termination so it happens after the wgpu surface is deleted. 