### PR TITLE
Add pointer_enter and pointer_leave events

### DIFF
--- a/rendercanvas/_events.py
+++ b/rendercanvas/_events.py
@@ -22,8 +22,10 @@ class EventType(BaseEnum):
     resize = None  #: The canvas has changed size. Has 'width' and 'height' in logical pixels, 'pixel_ratio'.
     close = None  #: The canvas is closed. No additional fields.
     pointer_down = None  #: The pointing device is pressed down. Has 'x', 'y', 'button', 'butons', 'modifiers', 'ntouches', 'touches'.
-    pointer_up = None  #: The pointing device is released. Same fields as pointer_down.
-    pointer_move = None  #: The  pointing device is moved. Same fields as pointer_down.
+    pointer_up = None  #: The pointing device is released. Same fields as pointer_down. Can occur outside of the canvas.
+    pointer_move = None  #: The pointing device is moved. Same fields as pointer_down. Can occur outside of the canvas if the pointer is currently down.
+    pointer_enter = None  #: The pointing device is moved into the canvas.
+    pointer_leave = None  #: The pointing device is moved outside of the canvas (regardless of a button currently being pressed).
     double_click = None  #: A double-click / long-tap. This event looks like a pointer event, but without the touches.
     wheel = None  #: The mouse-wheel is used (scrolling), or the touchpad/touchscreen is scrolled/pinched. Has 'dx', 'dy', 'x', 'y', 'modifiers'.
     key_down = None  #: A key is pressed down. Has 'key', 'modifiers'.

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -519,6 +519,14 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
     def mouseReleaseEvent(self, event):  # noqa: N802
         self._mouse_event("pointer_up", event)
 
+    def enterEvent(self, event):  # noqa: N802
+        ev = {"event_type": "pointer_enter"}
+        self.submit_event(ev)
+
+    def leaveEvent(self, event):  # noqa: N802
+        ev = {"event_type": "pointer_leave"}
+        self.submit_event(ev)
+
     def mouseDoubleClickEvent(self, event):  # noqa: N802
         super().mouseDoubleClickEvent(event)
         self._mouse_event("double_click", event, touches=False)


### PR DESCRIPTION
Closes #78

### Implemented for
* glfw
* qt
* wx

(for jupyter it already works via jupyter_rfb since https://github.com/vispy/jupyter_rfb/pull/116)

### Behavior for all backends

*I made sure the below behavior is implemented in all backends.*

* Send enter / leave event when the mouse enters / leaves the window.
* The canvas does not emit pointer move events when the pointer has left the canvas, unless a button is pressed (i.e. dragging / mouse tracking).
* When the application loses focus, a leave event is emitted.
* When the application regains focus, an enter event is emitted if the pointer if over the canvas. 
* If the application regained focus by clicking on the canvas, that click does not result in pointer events (down, nor move, nor up).
* When the application does not have focus, it does not emit pointer move events.

Exceptions:
* On Wx on MacOS, there are no pointer move events at all when no button is pressed. This is a known issue.
* In glfw, if the window is initialized with the pointer over the canvas, the initial (very first) enter event is emitted when the mouse is moved.
* In the browser, when the application gains focus with the pointer over the canvas, the enter event is emitted when the mouse is moved.
