### PR TITLE
Add canvas.set_update_mode()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,11 +1,12 @@
 API
 ===
 
-These are the base classes that make up the rendercanvas API:
+These are the classes that make up the rendercanvas API:
 
 * The :class:`~rendercanvas.BaseRenderCanvas` represents the main API.
 * The :class:`~rendercanvas.BaseLoop` provides functionality to work with the event-loop in a generic way.
 * The :class:`~rendercanvas.EventType` enum specifies the types of events for :func:`canvas.add_event_handler() <rendercanvas.BaseRenderCanvas.add_event_handler>`.
+* The :class:`~rendercanvas.UpdateMode` enum specifies the scheduler behaviour for  :func:`canvas.set_update_mode() <rendercanvas.BaseRenderCanvas.set_update_mode>`.
 * The :class:`~rendercanvas.CursorShape` enum specifies the cursor shapes for :func:`canvas.set_cursor() <rendercanvas.BaseRenderCanvas.set_cursor>`.
 
 .. autoclass:: rendercanvas.BaseRenderCanvas
@@ -17,6 +18,10 @@ These are the base classes that make up the rendercanvas API:
     :member-order: bysource
 
 .. autoclass:: rendercanvas.EventType
+    :members:
+    :member-order: bysource
+
+.. autoclass:: rendercanvas.UpdateMode
     :members:
     :member-order: bysource
 

--- a/rendercanvas/__init__.py
+++ b/rendercanvas/__init__.py
@@ -7,6 +7,7 @@ RenderCanvas: one canvas API, multiple backends.
 from ._version import __version__, version_info
 from . import _coreutils
 from ._events import EventType
+from ._scheduler import UpdateMode
 from .base import BaseRenderCanvas, BaseLoop, CursorShape
 
-__all__ = ["BaseLoop", "BaseRenderCanvas", "CursorShape", "EventType"]
+__all__ = ["BaseLoop", "BaseRenderCanvas", "CursorShape", "EventType", "UpdateMode"]

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -358,7 +358,7 @@ class BaseRenderCanvas:
         """Set the update mode for scheduling draws.
 
         Arguments:
-            update_mode (update_mode): See :obj:`rendercanvas.UpdateMode`:
+            update_mode (UpdateMode): The mode for scheduling draws and events.
             min_fps (float): The minimum fps with update mode 'ondemand'.
             max_fps (float): The maximum fps with update mode 'ondemand' and 'continuous'.
 


### PR DESCRIPTION
This allows setting the `update_mode` and `max_fps` at runtime. Ref #79 

### API changes

The default `min_fps` was changed from 1 to 0, so that with update-mode 'ondemand' there really are no draws except from resizes.