### PR TITLE
Do not emit repeated `key_down` and `key_up` events

### DIFF
--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -625,7 +625,9 @@ class GlfwRenderCanvas(BaseRenderCanvas):
             "key": keyname,
             "modifiers": tuple(self._key_modifiers),
         }
-        self.submit_event(ev)
+
+        if not action == glfw.REPEAT:
+            self.submit_event(ev)
 
     def _on_char(self, window, char):
         # Undocumented char event to make imgui work, see https://github.com/pygfx/wgpu-py/issues/530

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -478,7 +478,9 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
             "key": KEY_MAP.get(event.key(), event.text()),
             "modifiers": modifiers,
         }
-        self.submit_event(ev)
+
+        if not event.isAutoRepeat():
+            self.submit_event(ev)
 
     def _char_input_event(self, char_str):
         ev = {

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -422,7 +422,9 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
             "key": KEY_MAP.get(event.GetKeyCode(), char_str),
             "modifiers": modifiers,
         }
-        self.submit_event(ev)
+
+        if not event.IsAutoRepeat():
+            self.submit_event(ev)
 
     def _char_input_event(self, char_str: Optional[str]):
         if char_str is None:


### PR DESCRIPTION
This pull request stops os-level repeated `key_down` and `key_up` events from emitting from the `qt`, `glfw`, and `wx` backends to event handlers.

### Rationale

On linux, when the user presses and holds a key, the operating system sends repeat `key_down` and `key_up` events continuously depending on the input rate, even if the user has not physically lifted the key.

This causes significant friction for if a user wants to detect when a key is held and released.

`jupyter_rfb` already [filters these events](https://github.com/vispy/jupyter_rfb/blob/f84110f2f53eca9f7a99484039bced49a4309ebc/js/lib/widget.js#L331-L345) from ever reaching the server framebuffer from the javascript client. This pull request standardizes that behavior on the `qt`, `glfw`, and `wx` backends.

(Also see #93!)