### PR TITLE
POC: event handling using await

### DIFF
--- a/examples/drag.py
+++ b/examples/drag.py
@@ -1,0 +1,60 @@
+"""
+Noise
+-----
+
+Simple example that uses the bitmap-context to show images of noise.
+"""
+
+# run_example = true
+
+import numpy as np
+from rendercanvas.auto import RenderCanvas, loop
+
+
+canvas = RenderCanvas(update_mode="continuous")
+context = canvas.get_context("bitmap")
+
+
+w, h = 12, 12
+currentpos = [1, 1]
+
+@canvas.request_draw
+def animate():
+    x, y = currentpos
+
+    bitmap = np.zeros((h, w, 4), np.uint8)
+    bitmap[y, x] = 255
+
+    context.set_bitmap(bitmap)
+
+
+
+@canvas.add_event_task
+async def foo(emitter):
+    while True:
+
+        # Wait for pointer down
+        event = await emitter.for_event("pointer_down")
+
+        # Does this select the current position of the active block?
+        width, height = canvas.get_logical_size()
+        x = int(w * event["x"] / width)
+        y = int(h * event["y"] / height)
+        if [x, y] != currentpos:
+            print("nope", x, y)
+            continue
+
+        # Move until pointer up
+        while True:
+            event = await emitter.for_event("pointer_move", "pointer_up")
+            if event["event_type"] == "pointer_up":
+                break
+
+            width, height = canvas.get_logical_size()
+            x = int(w * event["x"] / width)
+            y = int(h * event["y"] / height)
+            print(x, y)
+            currentpos[:] = x, y
+
+
+loop.run()

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -15,7 +15,7 @@ from ._scheduler import Scheduler, UpdateMode
 from ._coreutils import logger, log_exception, BaseEnum
 
 if TYPE_CHECKING:
-    from typing import Callable, List, Optional, Tuple
+    from typing import Callable, Coroutine, List, Optional, Tuple
 
     EventHandlerFunction = Callable[[dict], None]
     DrawFunction = Callable[[], None]
@@ -308,6 +308,12 @@ class BaseRenderCanvas:
 
     def remove_event_handler(self, callback: EventHandlerFunction, *types: str) -> None:
         return self._events.remove_handler(callback, *types)
+
+    def add_event_task(
+        self, async_func: Callable[[], Coroutine], name: str = "unnamed"
+    ):
+        loop = self._rc_canvas_group.get_loop()
+        loop.add_task(async_func, self._events)
 
     def submit_event(self, event: dict) -> None:
         # Not strictly necessary for normal use-cases, but this allows


### PR DESCRIPTION
This is a proof of concept for an idea to allow users to handle events using await. An event handling workflow can then be written as a single async function, which can be much easier than listening to multiple events and maintaining state across the handlers.

Example implementing drag:
```py
@canvas.add_event_task
async def foo(for_event):
    while True:

        # Wait for pointer down
        event = await for_event("pointer_down")

        # Does this select the current position of the active block?
        width, height = canvas.get_logical_size()
        x = int(w * event["x"] / width)
        y = int(h * event["y"] / height)
        if [x, y] != currentpos:
            print("nope", x, y)
            continue

        # Move until pointer up
        while True:
            event = await for_event("pointer_move", "pointer_up")
            if event["event_type"] == "pointer_up":
                break

            width, height = canvas.get_logical_size()
            x = int(w * event["x"] / width)
            y = int(h * event["y"] / height)
            print(x, y)
            currentpos[:] = x, y
```

The use-case that triggered me to think about this more is the lasso tool in FPL: https://github.com/fastplotlib/fastplotlib/pull/837

I'm curious to what @Korijn thinks of this idea from a design/API perspective, and what users like @kushalkolar, @hmaarrfk, @claydugo, @kingbedjed think of writing handlers this way. I think it should be an alternative to `add_event_handler`, not replace it.

Some notes regarding async:
* Yes, this works with any backend.
* Yes, you can also `await sleep()`, but you should `from rendercanvas.asyncs import sleep` to make it portable.
* Although, if you know the underlying loop is asyncio, you can do any asyncio stuff :)

Some caveats:
* If an exception occurs in the task, it stops the task completely, unless you add a `try except`. 

Some ideas:
* The argument into the function can be the `for_event()` instead of the emitted object (see example above).
* Use `canvas.add_event_task("pointer_down", func)` so the task is initiated for every mouse down, avoiding one `while loop`.
* Maybe could write this as a generator instead of a an async function to make it feel more 'confined' to events.
