### PR TITLE
Disallow max_fps=-1

### DIFF
--- a/rendercanvas/_scheduler.py
+++ b/rendercanvas/_scheduler.py
@@ -95,9 +95,9 @@ class Scheduler:
 
         if max_fps is not None:
             # For users setting max_fps=-1 to try to disable the fps cap, as was the way to go in wgpu.gui
-            if max_fps < 0:
+            if max_fps < 1:
                 raise ValueError(
-                    "max_fps should be a positive number. Use update_mode='fastest' to disable the fps cap. Also see ``vsync=False`` to unlock higher frame rates."
+                    "max_fps should be a >= 1. Use update_mode='fastest' to disable the fps cap. Also see ``vsync=False`` to unlock higher frame rates."
                 )
             self._max_fps = max(1, float(max_fps))
 

--- a/rendercanvas/_scheduler.py
+++ b/rendercanvas/_scheduler.py
@@ -94,6 +94,11 @@ class Scheduler:
             self._min_fps = max(0.0, float(min_fps))
 
         if max_fps is not None:
+            # For users setting max_fps=-1 to try to disable the fps cap, as was the way to go in wgpu.gui
+            if max_fps < 0:
+                raise ValueError(
+                    "max_fps should be a positive number. Use update_mode='fastest' to go as fast as possible."
+                )
             self._max_fps = max(1, float(max_fps))
 
     def request_draw(self):

--- a/rendercanvas/_scheduler.py
+++ b/rendercanvas/_scheduler.py
@@ -97,7 +97,7 @@ class Scheduler:
             # For users setting max_fps=-1 to try to disable the fps cap, as was the way to go in wgpu.gui
             if max_fps < 0:
                 raise ValueError(
-                    "max_fps should be a positive number. Use update_mode='fastest' to go as fast as possible."
+                    "max_fps should be a positive number. Use update_mode='fastest' to disable the fps cap. Also see ``vsync=False`` to unlock higher frame rates."
                 )
             self._max_fps = max(1, float(max_fps))
 

--- a/rendercanvas/_version.py
+++ b/rendercanvas/_version.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 # This is the reference version number, to be bumped before each release.
 # The build system detects this definition when building a distribution.
-__version__ = "2.1.2"
+__version__ = "2.2.0"
 
 # Allow using nearly the same code in different projects
 project_name = "rendercanvas"


### PR DESCRIPTION
In `wgpu.gui`, one could set `max_fps=-1` to disable the fps cap. Several examples in pygfx do this. In rendercanvas this results in a cap of 1 fps. To avoid frustration about "why the visualization is so slow", let's forbid negative fps caps.