### PR TITLE
Improve typing

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -37,9 +37,13 @@ canvas.request_draw(draw_frame)
 # Note: in this demo we listen to all events (using '*'). In general
 # you want to select one or more specific events to handle.
 
+cursor_index = 0
+
 
 @canvas.add_event_handler("*")
 async def process_event(event):
+    global cursor_index
+
     if event["event_type"] not in ["pointer_move", "before_draw", "animate"]:
         print(event)
 
@@ -62,10 +66,10 @@ async def process_event(event):
         elif event["key"] == "c":
             # Swap cursor
             shapes = list(rendercanvas.CursorShape)
-            canvas.cursor_index = getattr(canvas, "cursor_index", -1) + 1
-            if canvas.cursor_index >= len(shapes):
-                canvas.cursor_index = 0
-            cursor = shapes[canvas.cursor_index]
+            cursor_index += 1
+            if cursor_index >= len(shapes):
+                cursor_index = 0
+            cursor = shapes[cursor_index]
             canvas.set_cursor(cursor)
             print(f"Cursor: {cursor!r}")
     elif event["event_type"] == "close":

--- a/rendercanvas/_coreutils.py
+++ b/rendercanvas/_coreutils.py
@@ -41,7 +41,7 @@ def log_exception(kind):
     except Exception as err:
         # Store exc info for postmortem debugging
         exc_info = list(sys.exc_info())
-        exc_info[2] = exc_info[2].tb_next  # skip *this* function
+        exc_info[2] = exc_info[2].tb_next  # type: ignore | skip *this* function
         sys.last_type, sys.last_value, sys.last_traceback = exc_info
         # Show traceback, or a one-line summary
         msg = str(err)

--- a/rendercanvas/_loop.py
+++ b/rendercanvas/_loop.py
@@ -139,9 +139,14 @@ class BaseLoop:
                     break
                 elif self.__should_stop:
                     # Close all remaining canvases. Loop will stop in a next iteration.
+                    # We store a flag on the canvas, that we only use here.
                     for canvas in self.get_canvases():
-                        if not canvas._rc_closed_by_loop:
-                            canvas._rc_closed_by_loop = True
+                        try:
+                            closed_by_loop = canvas._rc_closed_by_loop  # type: ignore
+                        except AttributeError:
+                            closed_by_loop = False
+                        if not closed_by_loop:
+                            canvas._rc_closed_by_loop = True  # type: ignore
                             canvas.close()
                         del canvas
 

--- a/rendercanvas/_loop.py
+++ b/rendercanvas/_loop.py
@@ -140,7 +140,7 @@ class BaseLoop:
                 elif self.__should_stop:
                     # Close all remaining canvases. Loop will stop in a next iteration.
                     for canvas in self.get_canvases():
-                        if not getattr(canvas, "_rc_closed_by_loop", False):
+                        if not canvas._rc_closed_by_loop:
                             canvas._rc_closed_by_loop = True
                             canvas.close()
                         del canvas

--- a/rendercanvas/_scheduler.py
+++ b/rendercanvas/_scheduler.py
@@ -44,7 +44,7 @@ class Scheduler:
     # don't affect the scheduling loop; they are just extra draws.
 
     def __init__(
-        self, canvas, events, *, update_mode="ondemand", min_fps=0, max_fps=30
+        self, canvas, events, *, update_mode="ondemand", min_fps=0.0, max_fps=30.0
     ):
         self.name = f"{canvas.__class__.__name__} scheduler"
 
@@ -65,7 +65,7 @@ class Scheduler:
     def get_task(self):
         """Get task. Can be called exactly once. Used by the canvas."""
         task = self.__scheduler_task
-        self.__scheduler_task = None
+        self.__scheduler_task = None  # type: ignore
         assert task is not None
         return task
 
@@ -102,7 +102,7 @@ class Scheduler:
         self._draw_requested = True
 
     async def __scheduler_task(self):
-        """The coro that reprsents the scheduling loop for a canvas."""
+        """The coro that represents the scheduling loop for a canvas."""
 
         last_draw_time = 0
         last_tick_time = 0

--- a/rendercanvas/auto.py
+++ b/rendercanvas/auto.py
@@ -40,6 +40,8 @@ def select_backend():
     module = None
     failed_backends = {}  # name -> error
 
+    backend_name = "none"
+    reason = "no reason"
     for backend_name, reason in backends_generator():
         if "force" in reason.lower():
             return _load_backend(backend_name)
@@ -122,7 +124,7 @@ def backends_by_env_vars():
 def backends_by_jupyter():
     """Generate backend names that are appropriate for the current Jupyter session (if any)."""
     try:
-        ip = get_ipython()
+        ip = get_ipython()  # type: ignore
     except NameError:
         return
     if not ip.has_trait("kernel"):

--- a/rendercanvas/utils/cube.py
+++ b/rendercanvas/utils/cube.py
@@ -4,6 +4,7 @@ A wgpu example showing a rotating cube. Provides ``setup_drawing_sync()`` and
 """
 
 import time
+from typing import Callable
 
 import wgpu
 import numpy as np
@@ -14,7 +15,7 @@ import numpy as np
 
 def setup_drawing_sync(
     canvas, power_preference="high-performance", limits=None, format=None
-):
+) -> Callable[[], None]:
     """Setup to draw a rotating cube on the given canvas.
 
     The given canvas must implement WgpuCanvasInterface, but nothing more.
@@ -220,7 +221,7 @@ def create_pipeline_layout(device):
 
 def get_draw_function(
     canvas, device, render_pipeline, uniform_buffer, bind_groups, *, asynchronous
-):
+) -> Callable[[], None]:
     # Create vertex buffer, and upload data
     vertex_buffer = device.create_buffer_with_data(
         data=vertex_data, usage=wgpu.BufferUsage.VERTEX


### PR DESCRIPTION
With VSCode's Pylance set to "standard" I went through the "problems" it found.

* Applied small refactoring or a well-placed `# type: ignore` to make Pylance happy.
  *  Resolved all problems in the "base" modules.
  * Did not touch the backend module much.
  * Examples should be without problems -> users who are strong on their type-checking should be able to use `rendercanvas` without getting type errors.
* Fixed one type error: `get_physical_size() -> Tuple[int]` should be `Tuple[int,int]`.
* Same for `get_logical_size()`.
* Found one case where `canvas.__scheduler` was used without checking it was None.
