### PR TITLE
Refactor internal _set_size_info()

### DIFF
--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -322,7 +322,9 @@ class BaseRenderCanvas:
 
     # %% Events
 
-    def _set_size_info(self, physical_size: Tuple[int, int], pixel_ratio: float):
+    def _set_size_info(
+        self, physical_width: int, physical_height: int, pixel_ratio: float
+    ):
         """Must be called by subclasses when their size changes.
 
         Backends must *not* submit a "resize" event; the base class takes care of that, because
@@ -335,7 +337,7 @@ class BaseRenderCanvas:
         zoom factor is multiplied with it to obtain the final pixel-ratio for
         this canvas.
         """
-        self.__size_info["physical_size"] = int(physical_size[0]), int(physical_size[1])
+        self.__size_info["physical_size"] = int(physical_width), int(physical_height)
         self.__size_info["native_pixel_ratio"] = float(pixel_ratio)
         self.__resolve_total_pixel_ratio_and_logical_size()
 
@@ -379,7 +381,7 @@ class BaseRenderCanvas:
         # Keep context up-to-date
         if self.__need_context_resize and self._canvas_context is not None:
             self.__need_context_resize = False
-            self._canvas_context._rc_set_size_info(self.__size_info)
+            self._canvas_context._rc_set_size_dict(self.__size_info)
 
         # Keep event listeners up-to-date
         if self.__need_size_event:

--- a/rendercanvas/contexts/basecontext.py
+++ b/rendercanvas/contexts/basecontext.py
@@ -46,7 +46,7 @@ class BaseContext:
                 pseudo_canvas, {"screen": self._present_info}
             )
 
-    def _rc_set_size_info(self, size_info: dict) -> None:
+    def _rc_set_size_dict(self, size_info: dict) -> None:
         """Called by the BaseRenderCanvas to update the size."""
         # Note that we store the dict itself, not a copy. So our size is always up-to-date,
         # but this function is called on resize nonetheless so we can pass resizes downstream.

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -269,10 +269,10 @@ class GlfwRenderCanvas(BaseRenderCanvas):
         # on some systems and in logical-pixels on other, we use the
         # framebuffer size and pixel ratio to derive the logical size.
         pixel_ratio = get_window_content_scale(self._window)[0]
-        psize = get_physical_size(self._window)
+        pwidth, pheight = get_physical_size(self._window)
 
         self._pixel_ratio = pixel_ratio  # store
-        self._set_size_info(psize, pixel_ratio)
+        self._set_size_info(pwidth, pheight, pixel_ratio)
 
     def _on_want_close(self, *args):
         # Called when the user attempts to close the window, for example by clicking the close widget in the title bar.

--- a/rendercanvas/jupyter.py
+++ b/rendercanvas/jupyter.py
@@ -105,11 +105,9 @@ class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
         elif event_type == "resize":
             logical_size = event["width"], event["height"]
             pixel_ratio = event["pixel_ratio"]
-            physical_size = (
-                int(logical_size[0] * pixel_ratio),
-                int(logical_size[1] * pixel_ratio),
-            )
-            self._set_size_info(physical_size, pixel_ratio)
+            pwidth = int(logical_size[0] * pixel_ratio)
+            pheight = int(logical_size[1] * pixel_ratio)
+            self._set_size_info(pwidth, pheight, pixel_ratio)
             self.request_draw()
             return
 

--- a/rendercanvas/offscreen.py
+++ b/rendercanvas/offscreen.py
@@ -72,12 +72,10 @@ class OffscreenRenderCanvas(BaseRenderCanvas):
 
     def _rc_set_logical_size(self, width, height):
         logical_size = float(width), float(height)
-
-        physical_size = (
-            int(logical_size[0] * self._pixel_ratio),
-            int(logical_size[1] * self._pixel_ratio),
-        )
-        self._set_size_info(physical_size, self._pixel_ratio)
+        pixel_ratio = self._pixel_ratio
+        pwidth = int(logical_size[0] * pixel_ratio)
+        pheight = int(logical_size[1] * pixel_ratio)
+        self._set_size_info(pwidth, pheight, pixel_ratio)
 
     def _rc_close(self):
         self._closed = True
@@ -100,8 +98,9 @@ class OffscreenRenderCanvas(BaseRenderCanvas):
 
         The logical size is re-calculated using the current pixel ratio.
         """
-        physical_size = int(width), int(height)
-        self._set_size_info(physical_size, self._pixel_ratio)
+        pwidth = int(width)
+        pheight = int(height)
+        self._set_size_info(pwidth, pheight, self._pixel_ratio)
 
     def set_pixel_ratio(self, pixel_ratio: float):
         """Set the pixel ratio, changing the logical size of the canvas.
@@ -110,8 +109,8 @@ class OffscreenRenderCanvas(BaseRenderCanvas):
         logical size, first set the pixel ratio and then the logical size.
         """
         self._pixel_ratio = float(pixel_ratio)
-        physical_size = self.get_physical_size()
-        self._set_size_info(physical_size, self._pixel_ratio)
+        pwidth, pheight = self.get_physical_size()
+        self._set_size_info(pwidth, pheight, self._pixel_ratio)
 
     def draw(self):
         """Perform a draw and get the resulting image.

--- a/rendercanvas/pyodide.py
+++ b/rendercanvas/pyodide.py
@@ -202,7 +202,8 @@ class PyodideRenderCanvas(BaseRenderCanvas):
             el.height = psize[1]
 
             # Notify the base class, so it knows our new size
-            self._set_size_info(psize, window.devicePixelRatio)
+            pwidth, pheight = psize
+            self._set_size_info(pwidth, pheight, window.devicePixelRatio)
 
         self._resize_callback_proxy = create_proxy(_resize_callback)
         self._resize_observer = ResizeObserver.new(self._resize_callback_proxy)

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -569,8 +569,9 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
         # but also add a small offset. Tested on Win10 with several different OS
         # scales. Would be nice if we could ask Qt for the exact physical size, but
         # we can't. Not an issue on qt5, because ratio is always integer then.
-        psize = round(lsize[0] * ratio + 0.01), round(lsize[1] * ratio + 0.01)
-        self._set_size_info(psize, ratio)
+        pwidth = round(lsize[0] * ratio + 0.01)
+        pheight = round(lsize[1] * ratio + 0.01)
+        self._set_size_info(pwidth, pheight, ratio)
         # self.update() / self.request_draw() is implicit
 
     def closeEvent(self, event):  # noqa: N802

--- a/rendercanvas/stub.py
+++ b/rendercanvas/stub.py
@@ -70,8 +70,8 @@ class StubRenderCanvas(BaseRenderCanvas):
     def _final_canvas_init(self):
         return super()._final_canvas_init()
 
-    def _set_size_info(self, physical_size, pixel_ratio):
-        return super()._set_size_info(physical_size, pixel_ratio)
+    def _set_size_info(self, physical_width, physical_height, pixel_ratio):
+        return super()._set_size_info(physical_width, physical_height, pixel_ratio)
 
     def _process_events(self):
         return super()._process_events()

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -384,8 +384,9 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         # * On Win10 this always returns 1 - so hidpi is effectively broken
         ratio = self.GetContentScaleFactor()
         # We use the same logic as for Qt to derive the physical size.
-        psize = round(lsize[0] * ratio + 0.01), round(lsize[1] * ratio + 0.01)
-        self._set_size_info(psize, ratio)
+        pwidth = round(lsize[0] * ratio + 0.01)
+        pheight = round(lsize[1] * ratio + 0.01)
+        self._set_size_info(pwidth, pheight, ratio)
 
     def _on_key_down(self, event: wx.KeyEvent):
         char_str = self._get_char_from_event(event)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -76,7 +76,7 @@ class MyOffscreenCanvas(rendercanvas.BaseRenderCanvas):
     def __init__(self):
         super().__init__()
         self.frame_count = 0
-        self._set_size_info((100, 100), 1)
+        self._set_size_info(100, 100, 1)
 
     def _rc_get_present_methods(self):
         return {
@@ -153,7 +153,7 @@ def test_simple_offscreen_canvas():
     assert np.all(canvas.array[:, :, 1] == 255)
 
     # Change resolution
-    canvas._set_size_info((120, 100), 1)
+    canvas._set_size_info(120, 100, 1)
 
     # Draw 3
     canvas.force_draw()
@@ -162,7 +162,7 @@ def test_simple_offscreen_canvas():
     assert np.all(canvas.array[:, :, 1] == 255)
 
     # Change resolution
-    canvas._set_size_info((120, 140), 1)
+    canvas._set_size_info(120, 140, 1)
 
     # Draw 4
     canvas.force_draw()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -44,7 +44,7 @@ class WgpuContextToBitmapLookLikeWgpuPy(WgpuContextToBitmap):
             "total_pixel_ratio": 1.0,
             "logical_size": (float(w), float(h)),
         }
-        self._rc_set_size_info(size_info)
+        self._rc_set_size_dict(size_info)
 
     def present(self):
         return self._rc_present()


### PR DESCRIPTION
Basically: ` _set_size_info(physical_size, pixel_ratio)`  -> ` _set_size_info(width, height, pixel_ratio)`. This is more consistent with other methods related to size.