### PR TITLE
bump pyscript in docs and examples

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -292,7 +292,7 @@ An example using PyScript (which uses Pyodide):
     <html>
     <head>
         <meta name="viewport" content="width=device-width,initial-scale=1.0">
-        <script type="module" src="https://pyscript.net/releases/2025.10.3/core.js"></script>
+        <script type="module" src="https://pyscript.net/releases/2025.11.1/core.js"></script>
     </head>
     <body>
         <canvas id='canvas' style="background:#aaa; width: 640px; height: 480px;"></canvas>

--- a/examples/pyscript.html
+++ b/examples/pyscript.html
@@ -4,7 +4,7 @@
 <head>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>RenderCanvas PyScript example</title>
-    <script type="module" src="https://pyscript.net/releases/2025.10.3/core.js"></script>
+    <script type="module" src="https://pyscript.net/releases/2025.11.1/core.js"></script>
 </head>
 
 <body>

--- a/examples/serve_browser_examples.py
+++ b/examples/serve_browser_examples.py
@@ -57,7 +57,7 @@ def get_html_index():
     <head>
         <meta name="viewport" content="width=device-width,initial-scale=1.0">
         <title>RenderCanvas PyScript examples</title>
-        <script type="module" src="https://pyscript.net/releases/2025.10.3/core.js"></script>
+        <script type="module" src="https://pyscript.net/releases/2025.11.1/core.js"></script>
     </head>
     <body>
 
@@ -84,7 +84,7 @@ pyscript_template = """
 <head>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>example.py via PyScript</title>
-    <script type="module" src="https://pyscript.net/releases/2025.10.3/core.js"></script>
+    <script type="module" src="https://pyscript.net/releases/2025.11.1/core.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
When using the release from pypi, pyscript showed an error like this 
<img width="702" height="208" alt="image" src="https://github.com/user-attachments/assets/ed74135b-e514-4ead-bc3a-08ef356faed5" />

I looked around and it appears like they have a list of "official" pyodide packages to check against. I am not sure how to be included there, maybe https://pyodide.org/en/stable/development/adding-packages-into-pyodide-distribution.html#adding-packages-into-pyodide-distribution. Although our implementation is pure python and doesn't need a recipe, so the pypi wheels are fine as they are.

Luckily there was a pyscript update just hours ago that addressed exactly this problem. Now shows a warning but works as expected. 

<img width="700" height="259" alt="image" src="https://github.com/user-attachments/assets/2ffc1c12-d54e-463a-93d1-6f4dce397098" />


This doesn't impact the docs or the serving script as that points to a local wheel, but I ran into this in the wgpu browser branch.