### PR TITLE
Resolve incompatible char events

### DIFF
--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -606,7 +606,8 @@ class GlfwRenderCanvas(BaseRenderCanvas):
         # Undocumented char event to make imgui work, see https://github.com/pygfx/wgpu-py/issues/530
         ev = {
             "event_type": "char",
-            "char_str": chr(char),
+            "data": chr(char),
+            "char_str": chr(char),  # compat, remove few months from nov '25
             "modifiers": tuple(self._key_modifiers),
         }
         self.submit_event(ev)

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -474,7 +474,8 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
     def _char_input_event(self, char_str):
         ev = {
             "event_type": "char",
-            "char_str": char_str,
+            "data": char_str,
+            "char_str": char_str,  # compat, remove few months from nov '25
             "modifiers": None,
         }
         self.submit_event(ev)

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -421,7 +421,8 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
 
         ev = {
             "event_type": "char",
-            "char_str": char_str,
+            "data": char_str,
+            "char_str": char_str,  # compat, remove few months from nov '25
             "modifiers": None,
         }
         self.submit_event(ev)


### PR DESCRIPTION
For char events, the text was stored in the 'data' fields for some backends (jupyter_rfb and Pyodide), and 'char_str' for others. Let's go with 'data' (similar to JS input events). In this PR, the backends that used 'char_str'  will now *also* have a 'data' field. We will remove the 'char_str' sometime later.