### PR TITLE
Make canvas.set_logical_size lazy again

### DIFF
--- a/rendercanvas/_size.py
+++ b/rendercanvas/_size.py
@@ -41,27 +41,6 @@ class SizeInfo(dict):
 
         self["changed"] = True
 
-    def set_logical_size(self, width: float, height: float):
-        """Called by the canvas when the logical size is set.
-
-        This calculates the expected physical size (with the current pixel ratio),
-        to get the corrected logical size. But this *only* sets the logical_size
-        and total_pixel_ratio. The backend will, likely before the next draw,
-        adjust the size and call set_physical_size(), which re-sets the logical size.
-        """
-        # Calculate adjusted logical size
-        ratio = self["native_pixel_ratio"] * self["canvas_pixel_ratio"]
-        pwidth = max(1, round(float(width) * ratio + 0.01))
-        pheight = max(1, round(float(height) * ratio + 0.01))
-        lwidth, lheight = pwidth / ratio, pheight / ratio
-
-        # Update logical size and total ratio. You could see it as a temporary zoom factor being applied.
-        # Note that The backend will soon call set_physical_size().
-        self["logical_size"] = lwidth, lheight
-        self["total_pixel_ratio"] = self["physical_size"][0] / lwidth
-
-        self["changed"] = True
-
     def set_zoom(self, zoom: float):
         """Set the zoom factor, i.e. the canvas pixel ratio."""
         self["canvas_pixel_ratio"] = float(zoom)

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -593,8 +593,6 @@ class BaseRenderCanvas:
         width, height = float(width), float(height)
         if width < 0 or height < 0:
             raise ValueError("Canvas width and height must not be negative")
-        # Already adjust our logical size, so e.g. layout engines can get to work
-        self._size_info.set_logical_size(width, height)
         # Tell the backend to adjust the size. It will likely set the new physical size before the next draw.
         self._rc_set_logical_size(width, height)
 

--- a/tests/test_size.py
+++ b/tests/test_size.py
@@ -31,57 +31,6 @@ def test_size_info_basic():
     assert si["changed"] is True
 
 
-def test_size_info_logical():
-    si = SizeInfo()
-    assert si["physical_size"] == (1, 1)
-    assert si["logical_size"] == (1.0, 1.0)
-    assert si["total_pixel_ratio"] == 1.0
-    assert si["changed"] is False
-
-    # Base class setting logical size
-    si.set_logical_size(100, 100)
-
-    assert si["physical_size"] == (1, 1)  # don't touch!
-    assert si["logical_size"] == (100.0, 100.0)
-    assert si["total_pixel_ratio"] == 0.01
-    assert si["changed"] is True
-
-    # Again
-    si.set_logical_size(640, 480)
-
-    assert si["physical_size"] == (1, 1)  # don't touch!
-    assert si["logical_size"] == (640.0, 480.0)
-    assert si["total_pixel_ratio"] == 1 / 640
-
-    # Now backend adjusts its actual size
-    si.set_physical_size(1280, 960, 2.0)
-
-    assert si["physical_size"] == (1280, 960)
-    assert si["logical_size"] == (640.0, 480.0)
-    assert si["total_pixel_ratio"] == 2.0
-
-    # Base class sets logical size again
-    si.set_logical_size(100.2, 100.2)
-
-    assert si["physical_size"] == (1280, 960)  # don't touch!
-    assert si["logical_size"] == (100.0, 100.0)  # took ratio into account
-    assert si["total_pixel_ratio"] == 1280 / 100
-
-    # And again
-    si.set_logical_size(101.8, 101.8)
-
-    assert si["physical_size"] == (1280, 960)  # don't touch!
-    assert si["logical_size"] == (102.0, 102.0)  # took ratio into account
-    assert si["total_pixel_ratio"] == 1280 / 102
-
-    # And backend adjusts its actual size
-    si.set_physical_size(204, 204, 2.0)
-
-    assert si["physical_size"] == (204, 204)
-    assert si["logical_size"] == (102, 102.0)
-    assert si["total_pixel_ratio"] == 2.0
-
-
 def test_size_info_zoom():
     si = SizeInfo()
     si.set_physical_size(1200, 1200, 2.0)
@@ -145,9 +94,9 @@ def test_canvas_sizing():
 
     c = MyRenderCanvas()
 
-    assert c.get_logical_size() == (640.0, 480.0)
+    assert c.get_logical_size() == (1.0, 1.0)
     assert c.get_physical_size() == (1, 1)
-    assert c.get_pixel_ratio() == 1 / 640
+    assert c.get_pixel_ratio() == 1
 
     c.apply_size()
 


### PR DESCRIPTION
In #141 I made it such that when `canvas.set_logical_size()` is called (either by the user, or as part of initializing the widget), the logical size of the widget is immediately set. Since the widget may take a while to actually resize (think of  widget embedded in a GUI, or a jupyter canvas), there is temporarily a very weird pixel ratio.

The idea for this change was that code that instantiate a widget and then directly try to use its logical size, have a (likely) correct value to work with already.

But I'm not pretty sure this was a mistake; the temporary phase were the logical size and physical size are "out of sync" is short, but it breaks assumptions, and makes it hard to explain what "logical size" really means.
