### PR TITLE
Better error message for typos in kwargs to RenderCanvas

### DIFF
--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -147,10 +147,7 @@ class BaseRenderCanvas:
         try:
             super().__init__(*args, **kwargs)
         except TypeError as err:
-            if (
-                sys.version_info >= (3, 11)
-                and "takes exactly one argument" in str(err)
-            ):
+            if sys.version_info >= (3, 11) and "takes exactly one argument" in str(err):
                 msg = "Instantiating a RenderCanvas with invalid "
                 if args and kwargs:
                     msg += f"args {args} and kwargs {kwargs}"


### PR DESCRIPTION
Passing args or kwargs to `object.__init__()` gives a silly error messages saying "object.__init__() takes exactly one argument (the instance to initialize)". When a user has a typo in one of rendercanvas's kwargs, this is not helpful. 

This PR detects the case and adds a note to the exception to clarify the situation.