### PR TITLE
fix crash when minimizing window

### DIFF
--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -357,7 +357,7 @@ class BaseRenderCanvas:
         if self._size_info["changed"]:
             self._size_info["changed"] = False
             # Keep context up-to-date
-            if self._canvas_context is not None:
+            if self._canvas_context is not None and all(i>=0 for i in self._size_info["physical_size"]):
                 self._canvas_context._rc_set_size_dict(self._size_info)
             # Keep event listeners up-to-date
             lsize = self._size_info["logical_size"]


### PR DESCRIPTION
PR is a fix for crash when minimizing window
OS: windows 11
backend: glfw/vulkan

output before fix :
``` python
File "...\rendercanvas\base.py", line 361, in __maybe_emit_resize_event
    self._canvas_context._rc_set_size_dict(self._size_info)
  File "...\rendercanvas\contexts\basecontext.py", line 54, in _rc_set_size_dict
    self._wgpu_context.set_physical_size(*size_info["physical_size"])
  File "...\wgpu\_classes.py", line 277, in set_physical_size
    raise ValueError("Physical size values must be positive.")
ValueError: Physical size values must be positive.
```

didn't feel like creating an issue on top of the PR.
Thx for the lib and happy new year👍