### PR TITLE
fix: fix wx scrolling

### DIFF
--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -5,7 +5,6 @@ can be used as a standalone window or in a larger GUI.
 
 __all__ = ["RenderCanvas", "WxLoop", "WxRenderCanvas", "WxRenderWidget", "loop"]
 
-import os
 import sys
 import time
 import ctypes


### PR DESCRIPTION
hey @almarklein 

this is a fix for scrolling on windows in wx, which is currently broken (see https://github.com/pyapp-kit/ndv/issues/116), but it will also slightly change the behavior on macos.

I tried to figure out what the "proper" fix is here, but the docs weren't super helpful.  So the numbers I came to here are a bit empirical ... after testing on both mac and windows, to match the experience of the qt backend.  

The one thing I'm confident about is that the previous code of `dy = delta * rotation` is definitely wrong.  It worked ok on macos because you get numbers like `delta=10, rotation=1`, but on windows you get `delta=120, rotation=120` and that leads to the "galaxy far away" phenotype described in the issue above (one step on the wheel and you're absolutely gone).

So, I'm confident that it needs to be scaled by rotation / delta.  But that leads to an *extremely* slow scroll.  So I'm adding a gain.  the 120 (on windows) exactly matches the Qt single wheel behavior, and on windows, scrolling the wheel faster simply emits more events at exactly the same rotation size.  On macos, however, faster scrolling leads to dramatically different rotation sizes (which is nice for UX: you get fine control at small speed and big change at high speed).

Anyway, I know the magic number doesn't feel great here.  So feel free to test/research however you like.  But I'm confident that things are fully broken on main for windows + wx.