### PR TITLE
Resize and title support for Pyodide canvases

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -290,9 +290,8 @@ additional dependencies. Currently only presenting a bitmap is supported, as
 shown in the examples :doc:`noise.py <gallery/noise>` and :doc:`snake.py<gallery/snake>`.
 Support for wgpu is underway.
 
-An HTMLCanvasElement is assumed to be present in the
-DOM. By default it connects to the canvas with id "canvas", but a
-different id or element can also be provided using ``RenderCanvas(canvas_element)``.
+The backend will render to an HTML ``<canvas>``. This can be provided with ``RenderCanvas(canvas_element='canvas')``,
+either by providing the element as an object, or via it's id. By default, it connects with the element with id "canvas".
 
 An example using PyScript (which uses Pyodide):
 
@@ -312,8 +311,34 @@ An example using PyScript (which uses Pyodide):
     </body>
     </html>
 
+The 'canvas_element' can also be a ``<div>`` element with the class 'rendercanvas-wrapper'. In this
+case the canvas will be created inside that wrapper, plus additional things to support features like
+a title bar and manual resizing. These features can be enabled with the 'has-titlebar' and 'is-resizable' css classes.
+The wrapper can also contain placeholder elements that will be deleted once the canvas is loaded:
 
-An example using Pyodide directly:
+.. code-block:: html
+
+    <!doctype html>
+    <html>
+    <head>
+        <meta name="viewport" content="width=device-width,initial-scale=1.0">
+        <script type="module" src="https://pyscript.net/releases/2025.11.1/core.js"></script>
+    </head>
+    <body>
+        <div id="canvas" class='renderview-wrapper is-resizable has-titlebar' style="width: 80%; height: 480px;">
+            <p style='width:100%; height:100%; background:#aaa; display: flex; justify-content: center; align-items: center; font-size:150%'>
+                Loading ...
+            </p>
+        </div>
+        <br>
+        <script type="py" src="yourcode.py" config='{"packages": ["numpy", "rendercanvas"]}'>
+        </script>
+    </body>
+    </html>
+
+
+It is also possible to use Pyodide directly. It requires a bit more plumbing.
+Similar as with PyScript, you can chose between a ``<canvas>``  and a ``<div class='renderview-wrapper'>``:
 
 .. code-block:: html
 

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -290,6 +290,9 @@ additional dependencies. Currently only presenting a bitmap is supported, as
 shown in the examples :doc:`noise.py <gallery/noise>` and :doc:`snake.py<gallery/snake>`.
 Support for wgpu is underway.
 
+The ``PyodideRenderCanvas`` has a few additional methods that are specific to the browser:
+``set_css_width``, ``set_css_height``, ``set_resizable``, and ``show_titlebar``.
+
 The backend will render to an HTML ``<canvas>``. This can be provided with ``RenderCanvas(canvas_element=...)``,
 either by providing the element as an object, or via it's id. By default, it connects with the element with id "canvas".
 

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -290,7 +290,7 @@ additional dependencies. Currently only presenting a bitmap is supported, as
 shown in the examples :doc:`noise.py <gallery/noise>` and :doc:`snake.py<gallery/snake>`.
 Support for wgpu is underway.
 
-The backend will render to an HTML ``<canvas>``. This can be provided with ``RenderCanvas(canvas_element='canvas')``,
+The backend will render to an HTML ``<canvas>``. This can be provided with ``RenderCanvas(canvas_element=...)``,
 either by providing the element as an object, or via it's id. By default, it connects with the element with id "canvas".
 
 An example using PyScript (which uses Pyodide):

--- a/docs/static/_pyodide_iframe.html
+++ b/docs/static/_pyodide_iframe.html
@@ -8,14 +8,17 @@
 </head>
 
 <body>
-    <dialog id="loading" style='outline: none; border: none; background: transparent;'>
-        <h1>Loading...</h1>
-    </dialog>
-    <canvas id='canvas' style='width:calc(100% - 20px); height: 450px; background-color: #ddd;'></canvas>
+
+    <div id="canvas" class='renderview-wrapper is-resizable has-titlebar'
+        style="width:calc(100% - 20px); height: 450px;">
+        <p id="loader"
+            style='width:100%; height:100%; background:#ddd; display: flex; justify-content: center; align-items: center; font-size:150%'>
+            Loading ...
+        </p>
+    </div>
+
     <script type="text/javascript">
         async function main() {
-            let loading = document.getElementById('loading');
-            loading.showModal();
             try {
                 let example_name = document.location.hash.slice(1);
                 pythonCode = await (await fetch(example_name)).text();
@@ -28,9 +31,8 @@
                 await micropip.install("rendercanvas");
                 // Run the Python code async because some calls are async it seems.
                 pyodide.runPythonAsync(pythonCode);
-                loading.close();
             } catch (err) {
-                loading.innerHTML = "Failed to load: " + err;
+                document.getElementById('loader').innerHTML = "Failed to load: " + err;
             }
         }
         main();

--- a/examples/pyscript.html
+++ b/examples/pyscript.html
@@ -8,16 +8,6 @@
 </head>
 
 <body>
-
-    <dialog id="loading" style='outline: none; border: none; background: transparent;'>
-        <h1>Loading...</h1>
-    </dialog>
-    <script type="module">
-        const loading = document.getElementById('loading');
-        addEventListener('py:ready', () => loading.close());
-        loading.showModal();
-    </script>
-
     <p>
         This example demonstrates using PyScript. It needs to be loaded through
         a web-server for it to access the Python file.
@@ -29,7 +19,12 @@
         there.
     </p>
 
-    <canvas id="canvas" style="background:#aaa; width: 90%; height: 480px;"></canvas>
+    <div id="canvas" class='renderview-wrapper is-resizable' style="width: 640px; height: 480px;">
+        <p
+            style='width:100%; height:100%; background:#aaa; display: flex; justify-content: center; align-items: center; font-size:150%'>
+            Loading ...
+        </p>
+    </div>
     <br>
     <script type="py" src="drag.py" config='{"packages": ["numpy", "rendercanvas"]}'>
     </script>

--- a/examples/serve_browser_examples.py
+++ b/examples/serve_browser_examples.py
@@ -89,20 +89,10 @@ pyscript_template = """
 
 <body>
     <a href="/">Back to list</a><br><br>
-
-    <p>
-    docstring
-    </p>
-    <dialog id="loading" style='outline: none; border: none; background: transparent;'>
-        <h1>Loading...</h1>
-    </dialog>
-    <script type="module">
-        const loading = document.getElementById('loading');
-        addEventListener('py:ready', () => loading.close());
-        loading.showModal();
-    </script>
-
-    <canvas id="canvas" style="background:#aaa; width: 90%; height: 480px;"></canvas>
+    <p>docstring</p>
+    <div id="canvas" class='renderview-wrapper is-resizable has-titlebar' style="width: 80%; height: 480px;">
+        <p style='width:100%; height:100%; background:#aaa; display: flex; justify-content: center; align-items: center; font-size:300%'>Loading ...</p>
+    </div>
     <script type="py" src="example.py" ,
         config='{"packages": ["numpy", "rendercanvas"]}'>
     </script>

--- a/examples/serve_browser_examples.py
+++ b/examples/serve_browser_examples.py
@@ -91,7 +91,7 @@ pyscript_template = """
     <a href="/">Back to list</a><br><br>
     <p>docstring</p>
     <div id="canvas" class='renderview-wrapper is-resizable has-titlebar' style="width: 80%; height: 480px;">
-        <p style='width:100%; height:100%; background:#aaa; display: flex; justify-content: center; align-items: center; font-size:300%'>Loading ...</p>
+        <p style='width:100%; height:100%; background:#aaa; display: flex; justify-content: center; align-items: center; font-size:150%'>Loading ...</p>
     </div>
     <script type="py" src="example.py" ,
         config='{"packages": ["numpy", "rendercanvas"]}'>

--- a/examples/snake.py
+++ b/examples/snake.py
@@ -12,7 +12,12 @@ import numpy as np
 from rendercanvas.auto import RenderCanvas, loop
 
 
-canvas = RenderCanvas(title="Snake on $backend", present_method=None, size=(640, 480), update_mode="continuous")
+canvas = RenderCanvas(
+    title="Snake on $backend",
+    present_method=None,
+    size=(640, 480),
+    update_mode="continuous",
+)
 
 context = canvas.get_bitmap_context()
 

--- a/examples/snake.py
+++ b/examples/snake.py
@@ -12,7 +12,7 @@ import numpy as np
 from rendercanvas.auto import RenderCanvas, loop
 
 
-canvas = RenderCanvas(present_method=None, size=(640, 480), update_mode="continuous")
+canvas = RenderCanvas(title="Snake on $backend", present_method=None, size=(640, 480), update_mode="continuous")
 
 context = canvas.get_bitmap_context()
 

--- a/rendercanvas/core/renderview-pyodide.js
+++ b/rendercanvas/core/renderview-pyodide.js
@@ -1,0 +1,60 @@
+/* global BaseRenderView Element HTMLDivElement HTMLCanvasElement */
+
+/**
+ * Adapter between the JS canvas and the Python canvas.
+ */
+class PyodideRenderView extends BaseRenderView {
+  constructor (canvasElement, pycanvas) {
+    let canvasId = null
+    let viewElement = null
+    let wrapperElement = null
+
+    // Turn element id into the element
+    if (typeof canvasElement === 'string' || canvasElement instanceof String) {
+      canvasId = canvasElement
+      canvasElement = document.getElementById(canvasId)
+      if (!canvasElement) {
+        throw new Error(`Given canvas id '${canvasId}' does not match an element in the DOM.`)
+      }
+    }
+
+    // Get whether we have a wrapper of an actual canvas
+    if (canvasElement instanceof HTMLCanvasElement) {
+      viewElement = canvasElement
+    } else if (canvasElement instanceof Element && canvasElement.classList.contains('renderview-wrapper')) {
+      wrapperElement = canvasElement
+      viewElement = document.createElement('canvas')
+    } else {
+      let repr = `${canvasElement}`
+      if (canvasId) {
+        repr = `id '${canvasId}' -> ` + repr
+      }
+      if (canvasElement instanceof HTMLDivElement) {
+        repr += ' (Maybe you forgot to add class=\'renderview-wrapper\'?)'
+      }
+      throw new Error('Given canvas element does not look like a <canvas>: ' + repr)
+    }
+
+    super(viewElement, wrapperElement)
+    this.pycanvas = pycanvas
+    this.setThrottle(0)
+  }
+
+  onVisibleChanged (visible) {
+    this.pycanvas._onVisibleChanged(visible)
+  }
+
+  onResize (physicalWidth, physicalHeight, pixelRatio) {
+    // Set canvas physical size
+    this.viewElement.width = physicalWidth
+    this.viewElement.height = physicalHeight
+    // Notify canvas, so the render code knows the size
+    this.pycanvas._onResize(physicalWidth, physicalHeight, pixelRatio)
+  }
+
+  onEvent (event) {
+    this.pycanvas._onEvent(event)
+  }
+}
+
+window.PyodideRenderView = PyodideRenderView

--- a/rendercanvas/core/renderview.css
+++ b/rendercanvas/core/renderview.css
@@ -1,4 +1,4 @@
-div.renderview-canvas-wrapper {
+div.renderview-wrapper {
     display: inline-block;
     position: relative;
     box-sizing: border-box;
@@ -7,16 +7,17 @@ div.renderview-canvas-wrapper {
     min-height: 32px;
 }
 
-div.renderview-canvas-wrapper img,
-div.renderview-canvas-wrapper canvas {
+div.renderview-wrapper img,
+div.renderview-wrapper canvas {
     display: block;
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    border-radius: 6px;
+    border-radius: 5px;
+    background: #777;
 }
 
-div.renderview-canvas-wrapper div.renderview-top {
+div.renderview-wrapper div.renderview-top {
     display: none;
     position: absolute;
     box-sizing: border-box;
@@ -25,20 +26,20 @@ div.renderview-canvas-wrapper div.renderview-top {
     height: 1.5em;
     width: 100%;
     border-top: 1px solid rgba(128, 128, 128, 0.5);
-    border-radius: 6px 6px 0 0;
+    border-radius: 5px 5px 0 0;
 }
 
-div.renderview-canvas-wrapper div.renderview-top span {
+div.renderview-wrapper div.renderview-top span {
     display: inline-block;
     box-sizing: border-box;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    padding: 0 0.5em 0 0.5em;
+    padding: 0.1em 0.5em;
     width: 100%;
 }
 
-div.renderview-canvas-wrapper div.renderview-resizer {
+div.renderview-wrapper div.renderview-resizer {
     display: none;
     position: absolute;
     box-sizing: border-box;
@@ -50,20 +51,20 @@ div.renderview-canvas-wrapper div.renderview-resizer {
     cursor: nwse-resize;
 }
 
-div.renderview-canvas-wrapper.has-titlebar {
-    margin-top: 2em;
+div.renderview-wrapper.has-titlebar {
+    margin-top: 2em !important;
 }
 
-div.renderview-canvas-wrapper.has-titlebar div.renderview-top {
+div.renderview-wrapper.has-titlebar div.renderview-top {
     display: block;
 }
 
-div.renderview-canvas-wrapper.has-titlebar img,
-div.renderview-canvas-wrapper.has-titlebar canvas {
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+div.renderview-wrapper.has-titlebar img,
+div.renderview-wrapper.has-titlebar canvas {
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
 }
 
-div.renderview-canvas-wrapper.is-resizable div.renderview-resizer {
+div.renderview-wrapper.is-resizable div.renderview-resizer {
     display: block;
 }

--- a/rendercanvas/core/renderview.css
+++ b/rendercanvas/core/renderview.css
@@ -13,7 +13,7 @@ div.renderview-wrapper canvas {
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    border-radius: 5px;
+    border-radius: 6px;
     background: #777;
 }
 
@@ -25,8 +25,8 @@ div.renderview-wrapper div.renderview-top {
     top: -1.5em;
     height: 1.5em;
     width: 100%;
-    border-top: 1px solid rgba(128, 128, 128, 0.5);
-    border-radius: 5px 5px 0 0;
+    border-radius: 6px 6px 0 0;
+    box-shadow: 0px -2px 0px 0px rgba(128, 128, 128, 0.5);
 }
 
 div.renderview-wrapper div.renderview-top span {
@@ -46,8 +46,8 @@ div.renderview-wrapper div.renderview-resizer {
     z-index: 3;
     bottom: 0;
     right: 0;
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     cursor: nwse-resize;
 }
 

--- a/rendercanvas/core/renderview.js
+++ b/rendercanvas/core/renderview.js
@@ -82,16 +82,13 @@ function arraysEqual (a, b) {
  * - it observes resizes and calls `this.OnResize()`.
  * - it observes user events ans calls this.OnEvent()`.
  *
- * It provides convenience methods:
- *
- * - `setCssSize()` to set the size on the appropriate element.
- * - `setCursor()` to set the `style.cursor`.
- * - `setThrottle()` for move and wheel events.
+ * It provides convenience methods for setting the size, cursor, and more.
  *
  * When used with a wrapper element, more features are enabled:
  *
- * - It can be manually resized if the wrapper has the 'is-resizable' class.
+ * - It can be manually resized if the wrapper element has the 'is-resizable' class.
  * - A title bar is shown if the wrapper has the 'has-titlebar' class.
+ * - The above mentioned classes can also be programmatically set via `setResizable()` and `showTitlebar()`.
  * - The title can be set using `setTitle()`.
  *
  */
@@ -103,7 +100,7 @@ class BaseRenderView {
    * No styling is applied except for `width` and `height`.
    *
    * If a wrapper element is also given, the view supports features like manual resizing and a title-bar.
-   * In this case, any styling that effects positioning should be applied to the wrapper.
+   * In this case, any user styling that effects positioning should be applied to the wrapper.
    * The wrapper may contain placeholder content; on initialization, it's innerHTML and padding are reset.
    *
    * @param {HTMLElement} viewElement - The element (e.g. canvas or img) used for rendering.
@@ -120,6 +117,7 @@ class BaseRenderView {
       }
       wrapperElement.innerHTML = ''
       wrapperElement.style.padding = '0'
+      wrapperElement.style.background = ''
     }
 
     // Tweak viewElement
@@ -138,12 +136,13 @@ class BaseRenderView {
     this.wrapperElement = wrapperElement
     this.sizeElement = (wrapperElement === null) ? viewElement : wrapperElement
 
-    this._wheelThrottle = 20
-    this._moveThrottle = 20
+    this._lsize = null // cached logical size
+    this._wheelThrottle = 20 // to avoid flooding wheel events
+    this._moveThrottle = 20 // to avoid flooding move events
     this._isVisible = false // set by intersection observer
 
-    this._abortController = new AbortController()
     this._focusElement = null
+    this._abortController = new AbortController()
     this._resizeObserver = null
     this._intersectionObserver = null
 
@@ -156,13 +155,13 @@ class BaseRenderView {
    * This does not remove the the element from the DOM; that's up to the caller.
    */
   close () {
-    if (this._abortController) {
-      this._abortController.abort()
-      this._abortController = null
-    }
     if (this._focusElement) {
       this._focusElement.remove()
       this._focusElement = null
+    }
+    if (this._abortController) {
+      this._abortController.abort()
+      this._abortController = null
     }
     if (this._resizeObserver) {
       this._resizeObserver.disconnect()
@@ -175,18 +174,82 @@ class BaseRenderView {
   }
 
   /**
-   * Set the size of the view, expressed as CSS. Use e.g. '640px' to set in logical pixels.
-   * If setting the new size affects the actual size of the view, `OnResize()` will be called.
+   * Set the view's size in logical pixels.
    *
-   * @param {string} cssWidth - The requested width.
-   * @param {string} cssHeight - The requested height.
+   * @param {string} width - The requested width.
+   * @param {string} height - The requested height.
    */
-  setCssSize (cssWidth, cssHeight) {
-    // Sets the intended size of the container element (which may be the same element as the view element)
+  setLogicalSize (width, height) {
     this.sizeElement.style.maxWidth = ''
     this.sizeElement.style.maxHeight = ''
+    this.sizeElement.style.width = width + 'px'
+    this.sizeElement.style.height = height + 'px'
+  }
+
+  /**
+   * Set the width of the view as a CSS string.
+   *
+   * @param {string} cssWidth - The requested width as a css string, e.g. '640px' or '90%' or 'calc(100% - 10px)'.
+   */
+  setCssWidth (cssWidth) {
+    this.sizeElement.style.maxWidth = ''
     this.sizeElement.style.width = cssWidth
+  }
+
+  /**
+   * Set the height of the view as a CSS string.
+   *
+   * @param {string} cssHeight - The requested height as a css string, e.g. '480px' or '40vh'.
+   */
+  setCssHeight (cssHeight) {
+    this.sizeElement.style.maxHeight = ''
     this.sizeElement.style.height = cssHeight
+  }
+
+  /**
+  * Set whether the view is manually resizable.
+  * Note that the view can only be made resizable if it was instantiated with a wrapper.
+  *
+  * @param {boolean} resizable - Whether to make it resizable or not.
+  */
+  setResizable (resizable) {
+    if (this.wrapperElement) {
+      if (resizable) {
+        this.wrapperElement.classList.add('is-resizable')
+      } else {
+        this.wrapperElement.classList.remove('is-resizable')
+      }
+    }
+  }
+
+  /**
+  * Set whether the view has a titlebar.
+  * Note that the view can only have a titlebar if it was instantiated with a wrapper.
+  *
+  * @param {boolean} titlebar - Whether to show the titlebar or not.
+  */
+  showTitlebar (titlebar) {
+    if (this.wrapperElement) {
+      if (titlebar) {
+        this.wrapperElement.classList.add('has-titlebar')
+      } else {
+        this.wrapperElement.classList.remove('has-titlebar')
+      }
+    }
+  }
+
+  /**
+   * Set the view's title in the titlebar.
+   *
+   * Note that the title is only visible if the view was instantiated with a wrapper,
+   * and the titlebar is shown.
+   *
+   * @param {string} title - The title to set.
+   */
+  setTitle (title) {
+    if (this.titleElement) {
+      this.titleElement.innerText = title
+    }
   }
 
   /**
@@ -196,18 +259,6 @@ class BaseRenderView {
    */
   setCursor (cursor) {
     this.viewElement.style.cursor = cursor
-  }
-
-  /**
-   * Set the view's title.
-   *
-   * Note that the title is only visible if the view was instantiated with a wrapper,
-   * and that wrapper has the 'renderview-has-titlebar' class.
-   */
-  setTitle (title) {
-    if (this.titleElement) {
-      this.titleElement.innerText = title
-    }
   }
 
   /**
@@ -232,7 +283,7 @@ class BaseRenderView {
    *
    * @param {number} physicalWidth - The width in (physical) pixels.
    * @param {number} physicalHeight - The height in (physical) pixels.
-   * @param {number} pixelRatio - The pixel ratio. Multiply this with the physical size to get the logical size.
+   * @param {number} pixelRatio - The pixel ratio. Divide the physical size with this to get the logical size.
    */
   onResize (physicalWidth, physicalHeight, pixelRatio) { }
 
@@ -301,18 +352,15 @@ class BaseRenderView {
       wrapperElement.appendChild(resizeElement)
       let resizeInfo = null
       resizeElement.addEventListener('pointerdown', (ev) => {
-        console.log('resize start!', this.sizeElement._rc_width)
-        if (this.sizeElement._rc_width !== undefined) {
-          resizeInfo = { w: this.sizeElement._rc_width, h: this.sizeElement._rc_height, x: ev.clientX, y: ev.clientY }
+        if (this._lsize) {
+          resizeInfo = { w: this._lsize[0], h: this._lsize[1], x: ev.clientX, y: ev.clientY }
           resizeElement.setPointerCapture(ev.pointerId)
         }
       },
       { signal }
       )
       resizeElement.addEventListener('pointermove', (ev) => {
-        console.log('resizing!', resizeInfo)
         if (resizeInfo !== null) {
-          console.log(resizeInfo.w + (ev.clientX - resizeInfo.x))
           this.sizeElement.style.maxWidth = ''
           this.sizeElement.style.maxHeight = ''
           this.sizeElement.style.width = resizeInfo.w + (ev.clientX - resizeInfo.x) + 'px'
@@ -394,17 +442,18 @@ class BaseRenderView {
       // If the container element does not have its size set via its style, we set it to the logical size.
       const logicalWidth = physicalWidth / ratio
       const logicalHeight = physicalHeight / ratio
-      if ((!this.sizeElement.style.width) || (!this.sizeElement.style.height)) {
-        window.view2 = this
+
+      // prevent massive size due to auto-scroll (https://github.com/vispy/jupyter_rfb/issues/62)
+      if (!this.sizeElement.style.width) {
         this.sizeElement.style.width = `${logicalWidth}px`
+        this.sizeElement.style.maxWidth = '90vmin'
+      }
+      if (!this.sizeElement.style.height) {
         this.sizeElement.style.height = `${logicalHeight}px`
-        // prevent massive size due to auto-scroll (https://github.com/vispy/jupyter_rfb/issues/62)
-        this.sizeElement.style.maxWidth = Math.max(1024, window.innerWidth) + 'px'
-        this.sizeElement.style.maxHeight = Math.max(1024, window.innerHeight) + 'px'
+        this.sizeElement.style.maxHeight = '90vmin'
       }
 
-      this.sizeElement._rc_width = logicalWidth
-      this.sizeElement._rc_height = logicalHeight
+      this._lsize = [logicalWidth, logicalHeight]
       this.onResize(physicalWidth, physicalHeight, ratio)
     })
 

--- a/rendercanvas/core/renderview.js
+++ b/rendercanvas/core/renderview.js
@@ -1,12 +1,10 @@
 /*************************************************************************************************
   renderview.js
 
-  This module implements a common event spec for render targets in a browser. It
-  implements observers and event listeners and converts these into event
-  objects/dictionaries. The code is written with little assumptions about the
-  application, so that it can be shared between different use-cases, such as
-  rendercanvas backends (pyodide, anywidget, remote-browser), jupyter_rfb, and
-  other projects.
+  This module implements a common event spec for render targets in a browser.
+  The code is written with little assumptions about the application, so that it
+  can be shared between different use-cases, such as rendercanvas backends
+  (pyodide, anywidget, remote-browser), jupyter_rfb, and other projects.
 
   Code that loads this script should avoid loading it in the global scope.
   Either by putting it in a ``<script type='module>``, or wrapping it in an IIFE
@@ -76,33 +74,76 @@ function arraysEqual (a, b) {
 }
 
 /**
- * View that manages a render canvas inside a container element.
+ * The BaseRenderView handles the client-side logic for a render target (typically a <canvas> or <img>).
+ *
+ * It observes events:
+ *
+ * - it observes visibility and calls `this.OnVisibleChanged()`.
+ * - it observes resizes and calls `this.OnResize()`.
+ * - it observes user events ans calls this.OnEvent()`.
+ *
+ * It provides convenience methods:
+ *
+ * - `setCssSize()` to set the size on the appropriate element.
+ * - `setCursor()` to set the `style.cursor`.
+ * - `setThrottle()` for move and wheel events.
+ *
+ * When used with a wrapper element, more features are enabled:
+ *
+ * - It can be manually resized if the wrapper has the 'is-resizable' class.
+ * - A title bar is shown if the wrapper has the 'has-titlebar' class.
+ * - The title can be set using `setTitle()`.
+ *
  */
 class BaseRenderView {
   /**
    * Create a new RenderView.
    *
-   * @param {HTMLElement} viewElement - The canvas element used for rendering.
-   * @param {HTMLElement} wrapperElement - The element that holds the viewElement.
+   * If a single element is given, the view directly manages that element, nice and simple.
+   * No styling is applied except for `width` and `height`.
+   *
+   * If a wrapper element is also given, the view supports features like manual resizing and a title-bar.
+   * In this case, any styling that effects positioning should be applied to the wrapper.
+   * The wrapper may contain placeholder content; on initialization, it's innerHTML and padding are reset.
+   *
+   * @param {HTMLElement} viewElement - The element (e.g. canvas or img) used for rendering.
+   * @param {HTMLElement} wrapperElement - The wrapper element (optional; can be null).
    */
   constructor (viewElement, wrapperElement) {
+    // Check given element
     if (viewElement === undefined || !(viewElement instanceof Element)) {
-      throw new Error('BaseRenderView: viewElement must be an Element')
+      throw new Error('BaseRenderView: viewElement must be an Element.')
     }
-    if (wrapperElement === undefined || !(wrapperElement instanceof Element)) {
-      throw new Error('BaseRenderView: wrapperElement must be an Element')
+    if (wrapperElement !== null) {
+      if (wrapperElement === undefined || !(wrapperElement instanceof Element)) {
+        throw new Error('BaseRenderView: wrapperElement must be null or an Element.')
+      }
+      wrapperElement.innerHTML = ''
+      wrapperElement.style.padding = '0'
     }
+
+    // Tweak viewElement
+    viewElement.tabIndex = -1
+    // Prevent context menu on RMB. Firefox still shows it when shift is pressed. It seems
+    // impossible to override this (tips welcome!), so let's make this the actual behavior.
+    viewElement.oncontextmenu = (e) => {
+      if (!e.shiftKey) {
+        e.preventDefault()
+        e.stopPropagation()
+        return false
+      }
+    }
+
     this.viewElement = viewElement
     this.wrapperElement = wrapperElement
-    this.sizeElement = wrapperElement
+    this.sizeElement = (wrapperElement === null) ? viewElement : wrapperElement
 
     this._wheelThrottle = 20
     this._moveThrottle = 20
-
     this._isVisible = false // set by intersection observer
 
+    this._abortController = new AbortController()
     this._focusElement = null
-    this._abortController = null
     this._resizeObserver = null
     this._intersectionObserver = null
 
@@ -112,15 +153,16 @@ class BaseRenderView {
 
   /**
    * Close the view, disconnecting observers and clearing callbacks.
+   * This does not remove the the element from the DOM; that's up to the caller.
    */
   close () {
-    if (this._focusElement) {
-      this._focusElement.remove()
-      this._focusElement = null
-    }
     if (this._abortController) {
       this._abortController.abort()
       this._abortController = null
+    }
+    if (this._focusElement) {
+      this._focusElement.remove()
+      this._focusElement = null
     }
     if (this._resizeObserver) {
       this._resizeObserver.disconnect()
@@ -157,6 +199,18 @@ class BaseRenderView {
   }
 
   /**
+   * Set the view's title.
+   *
+   * Note that the title is only visible if the view was instantiated with a wrapper,
+   * and that wrapper has the 'renderview-has-titlebar' class.
+   */
+  setTitle (title) {
+    if (this.titleElement) {
+      this.titleElement.innerText = title
+    }
+  }
+
+  /**
    * Set the throttle setting. Set to zero to disable throttling.
    *
    * @param {number} throttle - The timeout (in ms) to wait before sending a move/wheel event.
@@ -190,9 +244,11 @@ class BaseRenderView {
   onEvent (event) { }
 
   /**
-   * Internal method to initialize the view's elements.
+   * Internal method to initialize the view's helper elements.
    */
   _initElements () {
+    const signal = this._abortController.signal
+
     // Obtain container to put our hidden focus element.
     // Putting the focusElement as a child of the canvas prevents chrome from emitting input events.
     const focusElementContainerId = 'rendercanvas-focus-element-container'
@@ -223,18 +279,54 @@ class BaseRenderView {
     focusElement.style.pointerEvents = 'none'
     focusElementContainer.appendChild(focusElement)
 
-    // Focus behavior
-    this.viewElement.tabIndex = -1
+    const wrapperElement = this.wrapperElement
 
-    // Prevent context menu on RMB. Firefox still shows it when shift is pressed. It seems
-    // impossible to override this (tips welcome!), so let's make this the actual behavior.
-    this.viewElement.oncontextmenu = (e) => {
-      if (!e.shiftKey) {
-        e.preventDefault()
-        e.stopPropagation()
-        return false
-      }
-    }
+    if (wrapperElement !== null) {
+      // Wrap it
+      wrapperElement.classList.add('renderview-wrapper')
+      wrapperElement.appendChild(this.viewElement)
+
+      // Create title bar
+      const topElement = document.createElement('div')
+      topElement.classList.add('renderview-top')
+      const titleElement = document.createElement('span')
+      this.titleElement = titleElement
+      titleElement.innerText = 'RenderView'
+      topElement.appendChild(titleElement)
+      wrapperElement.appendChild(topElement)
+
+      // Enable resizing
+      const resizeElement = document.createElement('div')
+      resizeElement.classList.add('renderview-resizer')
+      wrapperElement.appendChild(resizeElement)
+      let resizeInfo = null
+      resizeElement.addEventListener('pointerdown', (ev) => {
+        console.log('resize start!', this.sizeElement._rc_width)
+        if (this.sizeElement._rc_width !== undefined) {
+          resizeInfo = { w: this.sizeElement._rc_width, h: this.sizeElement._rc_height, x: ev.clientX, y: ev.clientY }
+          resizeElement.setPointerCapture(ev.pointerId)
+        }
+      },
+      { signal }
+      )
+      resizeElement.addEventListener('pointermove', (ev) => {
+        console.log('resizing!', resizeInfo)
+        if (resizeInfo !== null) {
+          console.log(resizeInfo.w + (ev.clientX - resizeInfo.x))
+          this.sizeElement.style.maxWidth = ''
+          this.sizeElement.style.maxHeight = ''
+          this.sizeElement.style.width = resizeInfo.w + (ev.clientX - resizeInfo.x) + 'px'
+          this.sizeElement.style.height = resizeInfo.h + (ev.clientY - resizeInfo.y) + 'px'
+        }
+      },
+      { signal }
+      )
+      resizeElement.addEventListener('lostpointercapture', (ev) => {
+        resizeInfo = null
+      },
+      { signal }
+      )
+    } // wrapperElement !== null
   }
 
   /**
@@ -244,7 +336,6 @@ class BaseRenderView {
     // Register events
 
     const viewElement = this.viewElement
-    this._abortController = new AbortController()
     const signal = this._abortController.signal // to unregister/abort stuff
 
     // ----- visibility ---------------
@@ -604,7 +695,7 @@ class BaseRenderView {
 
     this._focusElement.addEventListener('keydown', (ev) => {
       // Failsafe in case the element is deleted or detached.
-      if (this.wrapperElement.offsetParent === null) {
+      if (this.sizeElement.offsetParent === null) {
         return
       }
       // Ignore repeated events (key being held down)
@@ -627,7 +718,7 @@ class BaseRenderView {
     )
 
     this._focusElement.addEventListener('keyup', (ev) => {
-      if (this.wrapperElement.offsetParent === null) {
+      if (this.sizeElement.offsetParent === null) {
         return
       }
 
@@ -646,7 +737,7 @@ class BaseRenderView {
 
     this._focusElement.addEventListener('input', (ev) => {
       // Failsafe in case the element is deleted or detached.
-      if (this.wrapperElement.offsetParent === null) {
+      if (this.sizeElement.offsetParent === null) {
         return
       }
       // Prevent the text box from growing

--- a/rendercanvas/core/renderview.js
+++ b/rendercanvas/core/renderview.js
@@ -135,6 +135,7 @@ class BaseRenderView {
     this.viewElement = viewElement
     this.wrapperElement = wrapperElement
     this.sizeElement = (wrapperElement === null) ? viewElement : wrapperElement
+    this.titleElement = null // is set in _initElements() if wrapperElement is given
 
     this._lsize = null // cached logical size
     this._wheelThrottle = 20 // to avoid flooding wheel events
@@ -170,6 +171,13 @@ class BaseRenderView {
     if (this._intersectionObserver) {
       this._intersectionObserver.disconnect()
       this._intersectionObserver = null
+    }
+    this.viewElement = null
+    this.sizeElement = null
+    this.titleElement = null
+    if (this.wrapperElement) {
+      this.wrapperElement.innerHTML = ''
+      this.wrapperElement = null
     }
   }
 

--- a/rendercanvas/pyodide.py
+++ b/rendercanvas/pyodide.py
@@ -22,47 +22,19 @@ from pyodide.ffi import create_proxy, to_js
 from js import window, document, ImageData, Uint8ClampedArray, OffscreenCanvas
 
 
-pyodide_renderview_js = """
-/**
- * Adapter between the JS canvas and the Python canvas.
- * The BaseRenderView handles all events, visibility and resizing,
- * we just have to implement the hooks here.
- */
-class PyodideRenderView extends BaseRenderView {
-    constructor (jscanvas, pycanvas) {
-        super(jscanvas, jscanvas)
-        this.pycanvas = pycanvas
-        this.setThrottle(0)
-    }
-    onVisibleChanged(visible) {
-        this.pycanvas._onVisibleChanged(visible)
-    }
-    onResize(physicalWidth, physicalHeight, pixelRatio) {
-        // Set canvas physical size
-        this.viewElement.width = physicalWidth
-        this.viewElement.height = physicalHeight
-        // Notify canvas, so the render code knows the size
-        this.pycanvas._onResize(physicalWidth, physicalHeight, pixelRatio)
-    }
-    onEvent(event) {
-        this.pycanvas._onEvent(event)
-    }
-}
-window.PyodideRenderView = PyodideRenderView
-"""
-
-
 def _inject_js_and_css():
-    js_path = resource_files("rendercanvas.core").joinpath("renderview.js")
-    js = js_path.read_text() + pyodide_renderview_js
+    js = ""
+    for fname in ["renderview.js", "renderview-pyodide.js"]:
+        js_path = resource_files("rendercanvas.core").joinpath(fname)
+        js += js_path.read_text()
     js = "(function () {\n{JS}\n})();".replace("JS", js)  # wrap in IIFE module
     script_el = document.createElement("script")
-    script_el.text = js
+    script_el.textContent = js
     document.head.appendChild(script_el)
 
     css_path = resource_files("rendercanvas.core").joinpath("renderview.css")
     style_el = document.createElement("style")
-    style_el.text = css_path.read_text()
+    style_el.textContent = css_path.read_text()
     document.head.appendChild(style_el)
 
 
@@ -81,25 +53,13 @@ class PyodideRenderCanvas(BaseRenderCanvas):
 
     def __init__(
         self,
-        canvas_element: str = "canvas",
+        canvas_element: object = "canvas",
         *args,
         **kwargs,
     ):
-        # Resolve and check the canvas element
-        canvas_id = None
-        if isinstance(canvas_element, str):
-            canvas_id = canvas_element
-            canvas_element = document.getElementById(canvas_id)
-        if not (
-            hasattr(canvas_element, "tagName") and canvas_element.tagName == "CANVAS"
-        ):
-            repr = f"{canvas_element!r}"
-            if canvas_id:
-                repr = f"{canvas_id!r} -> " + repr
-            raise TypeError(
-                f"Given canvas element does not look like a <canvas>: {repr}"
-            )
-        self._canvas_element = canvas_element
+        # Create JS component that handles events and the embedding in the page
+        self._js_view = window.PyodideRenderView.new(canvas_element, create_proxy(self))
+        self._canvas_element = self._js_view.viewElement
 
         # We need a buffer to store pixel data, until we figure out how we can map a Python memoryview to a JS ArrayBuffer without making a copy.
         # TODO: if its any easier for a numpy array, we could go that route!
@@ -110,13 +70,9 @@ class PyodideRenderCanvas(BaseRenderCanvas):
 
         # If size or title are not given, set them to None, so they are left as-is. This is usually preferred in html docs.
         kwargs["size"] = kwargs.get("size", None)
-        kwargs["title"] = kwargs.get("title", None)
 
         # Finalize init
         super().__init__(*args, **kwargs)
-
-        self._js_view = window.PyodideRenderView.new(canvas_element, create_proxy(self))
-
         self._final_canvas_init()
 
     def _onVisibleChanged(self, visible):  # noqa: N802
@@ -259,7 +215,7 @@ class PyodideRenderCanvas(BaseRenderCanvas):
         # A canvas element doesn't have a title directly.
         # We assume that when the canvas sets a title it's the only one, and we set the title of the document.
         # Maybe we want a mechanism to prevent this at some point, we'll see.
-        document.title = title
+        self._js_view.setTitle(title)
 
     def _rc_set_cursor(self, cursor: str):
         self._js_view.setCursor(cursor)

--- a/rendercanvas/pyodide.py
+++ b/rendercanvas/pyodide.py
@@ -189,7 +189,7 @@ class PyodideRenderCanvas(BaseRenderCanvas):
             ctx.drawImage(self._offscreen_canvas, 0, 0, cw, ch)
 
     def _rc_set_logical_size(self, width: float, height: float):
-        self._js_view.setCssSize(f"{width}px", f"{height}px")
+        self._js_view.setLogicalSize(width, height)
 
     def _rc_close(self):
         # Closing is a bit weird in the browser ...
@@ -219,6 +219,30 @@ class PyodideRenderCanvas(BaseRenderCanvas):
 
     def _rc_set_cursor(self, cursor: str):
         self._js_view.setCursor(cursor)
+
+    def set_css_width(self, css_width: str):
+        """Set the width of the canvas as a CSS string."""
+        self._js_view.setCssWidth(css_width)
+
+    def set_css_height(self, css_height: str):
+        """Set the height of the canvas as a CSS string."""
+        self._js_view.setCssHeight(css_height)
+
+    def set_resizable(self, resizable: bool):
+        """Set whether the canvas is manually resizable.
+
+        Note that the canvas can only be made resizable if it was attached to a
+        wrapper HTML element (not directly to a ``<canvas>``).
+        """
+        self._js_view.setResizable(resizable)
+
+    def show_titlebar(self, titlebar: bool):
+        """Set whether the canvas has a titlebar.
+
+        Note that the canvas can only have a titlebar if it was attached to a
+        wrapper HTML element (not directly to a ``<canvas>``).
+        """
+        self._js_view.showTitlebar(titlebar)
 
 
 # Make available under a name that is the same for all backends


### PR DESCRIPTION
Instead of connecting the pyodide canvas to a `<canvas>`, it can now also be connected to a `<div class='renderview-wrapper'>`. When this is done, the a canvas will be created inside it, plus additional elements to support manual resizing, and a titlebar.

<img width="586" height="439" alt="image" src="https://github.com/user-attachments/assets/612c4902-6998-41f6-bb60-a333c1419916" />

*You can grab the bottom-right corner and drag it.*

An additional benefit is that content placed inside the wrapper will be deleted when the canvas loads; so its very easy to show a loading notification.

Side note: I started out with just replacing the `<canvas>` with a wrapper element, but that will cause all sorts of problems if users style their canvas, e.g. to position it. We'd have to transfer styles onto the wrapper and that will just become a mess. So I made it explicit. 

If a `<canvas>` is provided (the old approach), the JS code will not change its style at all (except width and height), providing a magic-less option for use-cases that need full control over the canvas.

The Pyodide canvas got a few new methods (the anywidget backend will have these too):
* `set_css_width()` and `set_css_height()`
* `set_resizable()`
* `show_titlebar()`
