### PR TITLE
Fix that Qt update() and wx Refresh did not cause a new draw

### DIFF
--- a/examples/wx_app.py
+++ b/examples/wx_app.py
@@ -19,9 +19,7 @@ class Example(wx.Frame):
         self.SetSize(640, 480)
 
         # Using present_method 'bitmap' because it reports "The surface texture is suboptimal"
-        self.canvas = RenderWidget(
-            self, update_mode="continuous", present_method="bitmap"
-        )
+        self.canvas = RenderWidget(self, update_mode="continuous")
         self.button = wx.Button(self, -1, "Hello world")
         self.output = wx.StaticText(self)
 

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -352,10 +352,9 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
             painter.drawImage(rect2, image, rect1)
             painter.end()
 
-    # def update(self):
-    #     # Bypass Qt's mechanics and request a draw so that the scheduling mechanics work as intended.
-    #     # Eventually this will call _request_draw().
-    #     self.request_draw()
+    def update(self):
+        # Bypass Qt's mechanics and request a draw, which will eventually call the native update()
+        self.request_draw()
 
     # %% Methods to implement RenderCanvas
 

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -240,7 +240,7 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
 
     def _on_resize_done(self, *args):
         self._draw_lock = False
-        self.Refresh()
+        self.request_draw()
 
     def on_paint(self, event):
         dc = wx.PaintDC(self)
@@ -251,6 +251,10 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         else:
             event.Skip()
         del dc
+
+    def Refresh(self):  # noqa: N802
+        # Bypass wx mechanics and request a draw, which will eventually call the native Refresh()
+        self.request_draw()
 
     def _get_surface_ids(self):
         if sys.platform.startswith("win") or sys.platform.startswith("darwin"):
@@ -322,12 +326,12 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         if self._draw_lock:
             return
         try:
-            self.Refresh()
+            wx.Window.Refresh(self)
         except Exception:
             pass  # avoid errors when window no longer lives
 
     def _rc_force_paint(self):
-        self.Refresh()
+        wx.Window.Refresh(self)
         self.Update()
         if sys.platform == "darwin":
             wx.Yield()
@@ -580,6 +584,10 @@ class WxRenderCanvas(WrapperRenderCanvas, wx.Frame):
 
         self.Show()
         self._final_canvas_init()
+
+    def Refresh(self):  # noqa: N802
+        self._subwidget.request_draw()
+        super().Refresh()
 
 
 # Make available under a name that is the same for all gui backends


### PR DESCRIPTION
Ref https://github.com/pygfx/pygfx/issues/1284

* Calling `widget.update()` on the Qt backend does not cause a redraw, when `present_method`  is 'bitmap' (the current default).
* Same for `widget.Refresh() for the wx backend.

For qt did worked earlier, but somehow some code got commented during #138 (i.e. a regression). For wx this was always broken.

This PR fixes both.