### PR TITLE
Backends that use renderview.js now check valid event types

### DIFF
--- a/rendercanvas/anywidget.py
+++ b/rendercanvas/anywidget.py
@@ -12,6 +12,7 @@ from importlib.resources import files as resource_files
 from .base import BaseCanvasGroup, BaseRenderCanvas, logger
 from .asyncio import loop
 from .core.encoders import encode_array, CAN_JPEG
+from .core.events import valid_event_types
 
 import numpy as np
 import anywidget
@@ -156,7 +157,7 @@ class AnywidgetRenderCanvas(BaseRenderCanvas, anywidget.AnyWidget):
                 )
             elif event_type == "close":
                 self.close()
-            else:
+            elif event_type in valid_event_types:
                 # Compatibility between new renderview event spec and current rendercanvas/pygfx events
                 event["event_type"] = event.pop("type")
                 event["time_stamp"] = event.pop("timestamp")

--- a/rendercanvas/jupyter.py
+++ b/rendercanvas/jupyter.py
@@ -8,7 +8,7 @@ __all__ = ["JupyterRenderCanvas", "RenderCanvas", "loop"]
 import time
 
 from .base import BaseCanvasGroup, BaseRenderCanvas
-from .core.events import EventType
+from .core.events import valid_event_types
 from .asyncio import loop
 
 import numpy as np
@@ -39,7 +39,6 @@ class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
         self._last_image = None
         self._is_closed = False
         self._draw_request_time = 0
-        self._rendercanvas_event_types = set(EventType)
 
         # The send_frame() method was added in jupyter_rfb 1.0, but it was always there as a private method,
         # so we can make it backwards compatible.
@@ -129,7 +128,7 @@ class JupyterRenderCanvas(BaseRenderCanvas, RemoteFrameBuffer):
 
         # Only submit events that rendercanvas knows. Otherwise, if new events are added
         # to jupyter_rfb that rendercanvas does not (yet) know, rendercanvas will complain.
-        if event_type in self._rendercanvas_event_types:
+        if event_type in valid_event_types:
             self.submit_event(event)
 
 

--- a/rendercanvas/pyodide.py
+++ b/rendercanvas/pyodide.py
@@ -14,6 +14,7 @@ from importlib.resources import files as resource_files
 
 from .base import BaseRenderCanvas, BaseCanvasGroup
 from .asyncio import loop
+from .core.events import valid_event_types
 
 if "pyodide" not in sys.modules:
     raise ImportError("This module is only for use with Pyodide in the browser.")
@@ -86,6 +87,10 @@ class PyodideRenderCanvas(BaseRenderCanvas):
     def _on_event(self, event):
         # Called from JS
         event = event.to_py()
+
+        # renderview.js may generate events that rendercanvas does not yet know
+        if event["type"] not in valid_event_types:
+            return
 
         # Compatibility between new renderview event spec and current rendercanvas/pygfx events
         event["event_type"] = event.pop("type")


### PR DESCRIPTION
As `renderview.js` evolves, it may introduce new events that rendercanvas does not know yet. In this case focus_in and focus_out.