### PR TITLE
Consistent GLFW backend detection on hybrid Wayland/X11 systems

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -135,6 +135,12 @@ By default, the ``glfw`` backend uses an event-loop based on asyncio. But you ca
     trio.run(main)
 
 
+For Linux users with Wayland: Glfw support on Wayland is ... complicated.
+Rendercanvas forces x11 mode by setting the env var ``PYGLFW_LIBRARY_VARIANT`` to 'x11'.
+To avoid this, e.g. when you want to use the system's ``libglfw3``, set ``PYGLFW_LIBRARY``
+or ``PYGLFW_LIBRARY_VARIANT``.
+
+
 Support for Qt
 --------------
 

--- a/rendercanvas/core/coreutils.py
+++ b/rendercanvas/core/coreutils.py
@@ -345,9 +345,6 @@ def close_agen(agen):
 SYSTEM_IS_WAYLAND = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
 
 if sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND:
-    # Force glfw to use X11. Note that this does not work if glfw is already imported.
-    if "glfw" not in sys.modules:
-        os.environ["PYGLFW_LIBRARY_VARIANT"] = "x11"
     # Force Qt to use X11. Qt is more flexible - it ok if e.g. PySide6 is already imported.
     os.environ["QT_QPA_PLATFORM"] = "xcb"
     # Force wx to use X11, probably.

--- a/rendercanvas/core/coreutils.py
+++ b/rendercanvas/core/coreutils.py
@@ -344,7 +344,24 @@ def close_agen(agen):
 
 SYSTEM_IS_WAYLAND = "wayland" in os.getenv("XDG_SESSION_TYPE", "").lower()
 
+
 if sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND:
+    # ----- Tweak glfw
+
+    # If you ``apt install glfw3``, you can force pyglfw to use it like so:
+    #
+    #    os.environ["PYGLFW_LIBRARY"] = "libglfw.so.3"
+
+    # Force glfw to use X11, unless it's too late or if the user seems to explicitly target a library.
+    if (
+        "glfw" not in sys.modules
+        and not os.environ.get("PYGLFW_LIBRARY_VARIANT")
+        and not os.environ.get("PYGLFW_LIBRARY")
+    ):
+        os.environ["PYGLFW_LIBRARY_VARIANT"] = "x11"
+
+    # ----- Tweak Qt
+
     # Force Qt to use X11. Qt is more flexible - it ok if e.g. PySide6 is already imported.
     os.environ["QT_QPA_PLATFORM"] = "xcb"
     # Force wx to use X11, probably.

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -17,7 +17,7 @@ import glfw
 
 from .base import BaseRenderCanvas, BaseCanvasGroup
 from .asyncio import loop
-from .core.coreutils import SYSTEM_IS_WAYLAND, weakbind, logger
+from .core.coreutils import SYSTEM_IS_WAYLAND, weakbind
 
 
 # Make sure that glfw is new enough
@@ -127,15 +127,20 @@ def get_glfw_present_info(window):
 
     elif sys.platform.startswith("linux"):
         # When the respective platform (X11 or Wayland) is not initialized, glfw emits a GLFWError warning and returns None. We treat None as "backend not active" here so that the warning carries no actionable information for the caller.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", glfw.GLFWError)
-            wayland_display = (
-                glfw.get_wayland_display()
-                if hasattr(glfw, "get_wayland_display")
-                else None
-            )
+        if SYSTEM_IS_WAYLAND:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", glfw.GLFWError)
+                wayland_display = (
+                    glfw.get_wayland_display()
+                    if hasattr(glfw, "get_wayland_display")
+                    else None
+                )
 
-        if wayland_display is not None:
+            if wayland_display is None:
+                raise RuntimeError(
+                    "GLFW Wayland backend is active but get_wayland_display() "
+                    "returned None. Is libglfw3-wayland installed?"
+                )
             return {
                 "method": "screen",
                 "platform": "wayland",
@@ -143,6 +148,7 @@ def get_glfw_present_info(window):
                 "display": int(wayland_display),
             }
 
+        # fall back to X11
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", glfw.GLFWError)
             x11_display = (

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -11,6 +11,7 @@ __all__ = ["GlfwRenderCanvas", "RenderCanvas", "loop"]
 
 import sys
 import time
+import warnings
 
 import glfw
 
@@ -28,10 +29,19 @@ if glfw_version_info < (1, 9):
 api_is_wayland = False
 if sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND:
     if not hasattr(glfw, "get_x11_window"):
-        # Probably glfw was imported before this module, so we missed our chance
+        # glfw was imported before this module, so we missed our chance
         # to set the env var to make glfw use x11.
         api_is_wayland = True
         logger.warning("Using GLFW with Wayland, which is experimental.")
+    else:
+        # On some systems glfw is built with both X11 and Wayland support.
+        # In that case get_x11_window exists but returns None when glfw is
+        # actually running on the Wayland backend. Log an info note so that
+        # the runtime check in get_glfw_present_info can handle this case.
+        logger.debug(
+            "GLFW has get_x11_window but system is Wayland; "
+            "will verify backend at runtime."
+        )
 
 
 # Some glfw functions are not always available
@@ -135,21 +145,47 @@ def get_glfw_present_info(window):
         }
 
     elif sys.platform.startswith("linux"):
-        if api_is_wayland:
+        # When the respective platform (X11 or Wayland) is not initialized, glfw emits a GLFWError warning and returns None. We treat None as "backend not active" here so that the warning carries no actionable information for the caller.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", glfw.GLFWError)
+            wayland_display = (
+                glfw.get_wayland_display()
+                if hasattr(glfw, "get_wayland_display")
+                else None
+            )
+
+        if api_is_wayland or wayland_display is not None:
+            if wayland_display is None:
+                raise RuntimeError(
+                    "GLFW Wayland backend is active but get_wayland_display() "
+                    "returned None. Is libglfw3-wayland installed?"
+                )
             return {
                 "method": "screen",
                 "platform": "wayland",
                 "window": int(glfw.get_wayland_window(window)),
-                "display": int(glfw.get_wayland_display()),
+                "display": int(wayland_display),
             }
 
-        else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", glfw.GLFWError)
+            x11_display = (
+                glfw.get_x11_display() if hasattr(glfw, "get_x11_display") else None
+            )
+        if x11_display is not None:
             return {
                 "method": "screen",
                 "platform": "x11",
                 "window": int(glfw.get_x11_window(window)),
-                "display": int(glfw.get_x11_display()),
+                "display": int(x11_display),
             }
+
+        raise RuntimeError(
+            "Cannot get GLFW surface info on Linux: neither a Wayland nor "
+            "an X11 display handle is available. "
+            "Make sure a display server is running and the matching glfw "
+            "library variant is installed."
+        )
 
     else:
         raise RuntimeError(f"Cannot get GLFW surface info on {sys.platform}.")

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -25,25 +25,6 @@ glfw_version_info = tuple(int(i) for i in glfw.__version__.split(".")[:2])
 if glfw_version_info < (1, 9):
     raise ImportError("rendercanvas requires glfw 1.9 or higher.")
 
-# Do checks to prevent pitfalls on hybrid Xorg/Wayland systems
-api_is_wayland = False
-if sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND:
-    if not hasattr(glfw, "get_x11_window"):
-        # glfw was imported before this module, so we missed our chance
-        # to set the env var to make glfw use x11.
-        api_is_wayland = True
-        logger.warning("Using GLFW with Wayland, which is experimental.")
-    else:
-        # On some systems glfw is built with both X11 and Wayland support.
-        # In that case get_x11_window exists but returns None when glfw is
-        # actually running on the Wayland backend. Log an info note so that
-        # the runtime check in get_glfw_present_info can handle this case.
-        logger.debug(
-            "GLFW has get_x11_window but system is Wayland; "
-            "will verify backend at runtime."
-        )
-
-
 # Some glfw functions are not always available
 set_window_content_scale_callback = lambda *args: None
 set_window_maximize_callback = lambda *args: None
@@ -154,12 +135,7 @@ def get_glfw_present_info(window):
                 else None
             )
 
-        if api_is_wayland or wayland_display is not None:
-            if wayland_display is None:
-                raise RuntimeError(
-                    "GLFW Wayland backend is active but get_wayland_display() "
-                    "returned None. Is libglfw3-wayland installed?"
-                )
+        if wayland_display is not None:
             return {
                 "method": "screen",
                 "platform": "wayland",

--- a/rendercanvas/glfw.py
+++ b/rendercanvas/glfw.py
@@ -17,7 +17,7 @@ import glfw
 
 from .base import BaseRenderCanvas, BaseCanvasGroup
 from .asyncio import loop
-from .core.coreutils import SYSTEM_IS_WAYLAND, weakbind
+from .core.coreutils import weakbind
 
 
 # Make sure that glfw is new enough
@@ -127,20 +127,15 @@ def get_glfw_present_info(window):
 
     elif sys.platform.startswith("linux"):
         # When the respective platform (X11 or Wayland) is not initialized, glfw emits a GLFWError warning and returns None. We treat None as "backend not active" here so that the warning carries no actionable information for the caller.
-        if SYSTEM_IS_WAYLAND:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", glfw.GLFWError)
-                wayland_display = (
-                    glfw.get_wayland_display()
-                    if hasattr(glfw, "get_wayland_display")
-                    else None
-                )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", glfw.GLFWError)
+            wayland_display = (
+                glfw.get_wayland_display()
+                if hasattr(glfw, "get_wayland_display")
+                else None
+            )
 
-            if wayland_display is None:
-                raise RuntimeError(
-                    "GLFW Wayland backend is active but get_wayland_display() "
-                    "returned None. Is libglfw3-wayland installed?"
-                )
+        if wayland_display is not None:
             return {
                 "method": "screen",
                 "platform": "wayland",
@@ -148,7 +143,7 @@ def get_glfw_present_info(window):
                 "display": int(wayland_display),
             }
 
-        # fall back to X11
+        # fall back to X11 if obtaining a wayland window handle fails (e.g. if Wayland is not available)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", glfw.GLFWError)
             x11_display = (


### PR DESCRIPTION
On linux systems where the glfw library supports  both X11 and Wayland (e.g. the universal `libglfw3` package), `get_x11_window` and `get_x11_display` are present as attributes even when glfw is actually running on the Wayland backend. The old detection logic relied solely on `hasattr(glfw, "get_x11_window")`, which incorrectly selected the X11 path and caused a `TypeError: ...` crash because `get_x11_display()` returned None.

This replaces the attribute check with a runtime probe of the actual display handles: `get_wayland_display()` is called first; `get_x11_display()` is only called when Wayland returns None. Both calls are wrapped in `warnings.catch_warnings(ignore, GLFWError)` to suppress "X11: Platform not initialized" / "Wayland: Platform not initialized" warnings from glfw.