### PR TITLE
Fix HDR support

### DIFF
--- a/rendercanvas/contexts/wgpucontext.py
+++ b/rendercanvas/contexts/wgpucontext.py
@@ -446,7 +446,6 @@ class ImageDownloader:
             "bytes_per_row": stride,
             "rows_per_image": texture.size[1],
         }
-
         # Copy data to temp buffer
         encoder = self._device.create_command_encoder()
         encoder.copy_texture_to_buffer(source, destination, texture.size)
@@ -491,7 +490,7 @@ class AsyncImageDownloadAction:
                 buffer.unmap()
             result = {
                 "method": "bitmap",
-                "format": "rgba-u8",
+                "format": self._short_format,
                 "data": data,
             }
             for callback in self._callbacks:
@@ -501,41 +500,16 @@ class AsyncImageDownloadAction:
 
     def _parse_texture_metadata(self, texture):
         size = texture.size
-        format = texture.format
-        nchannels = 4  # we expect rgba or bgra
 
-        if not format.startswith(("rgba", "bgra")):
-            raise RuntimeError(f"Image present unsupported texture format {format}.")
-        if "8" in format:
-            bytes_per_pixel = nchannels
-        elif "16" in format:
-            bytes_per_pixel = nchannels * 2
-        elif "32" in format:
-            bytes_per_pixel = nchannels * 4
-        else:
-            raise RuntimeError(
-                f"Image present unsupported texture format bitdepth {format}."
-            )
-
-        dtype = "uint8"
-        if "float" in format:
-            dtype = "float16" if "16" in format else "float32"
-        else:
-            dtype = "int" if "sint" in format else "uint"
-            if "32" in format:
-                dtype += "32"
-            elif "16" in format:
-                dtype += "16"
-            else:
-                dtype += "8"
+        self._dtype, self._short_format, self._nchannels, bytes_per_pixel = (
+            parse_format(texture.format)
+        )
 
         plain_stride = bytes_per_pixel * size[0]
         extra_stride = (256 - plain_stride % 256) % 256
         padded_stride = plain_stride + extra_stride
 
-        self._dtype = dtype
-        self._nchannels = nchannels
-        self._padded_stride = padded_stride
+        self._array_stride = padded_stride // bytes_per_pixel
         self._texture_size = size
 
         # For ImageDownloader
@@ -545,7 +519,7 @@ class AsyncImageDownloadAction:
     def _get_bitmap(self, buffer):
         dtype = self._dtype
         nchannels = self._nchannels
-        padded_stride = self._padded_stride
+        array_stride = self._array_stride
         size = self._texture_size
         plain_shape = (size[1], size[0], nchannels)
         present_params = self._present_params or {}
@@ -578,8 +552,8 @@ class AsyncImageDownloadAction:
             # This is the default.
 
             # Wrap the data in a (possible strided) numpy array
-            data = np.asarray(mapped_data, dtype=dtype).reshape(
-                plain_shape[0], padded_stride // nchannels, nchannels
+            data = np.frombuffer(mapped_data, dtype).reshape(
+                plain_shape[0], array_stride, nchannels
             )
             # Make a copy, making it contiguous.
             data = data[:, : plain_shape[1], :].copy()
@@ -589,8 +563,8 @@ class AsyncImageDownloadAction:
             # e.g. when the data must be uploaded to a GPU again.
 
             # Wrap the data in a (possible strided) numpy array
-            data = np.asarray(mapped_data, dtype=dtype).reshape(
-                plain_shape[0], padded_stride // nchannels, nchannels
+            data = np.frombuffer(mapped_data, dtype).reshape(
+                plain_shape[0], array_stride, nchannels
             )
             # Make a copy of the strided data, and create a view on that.
             data = data.copy()[:, : plain_shape[1], :]
@@ -601,8 +575,8 @@ class AsyncImageDownloadAction:
             import simplejpeg
 
             # Get strided array view
-            data = np.asarray(mapped_data, dtype=dtype).reshape(
-                plain_shape[0], padded_stride // nchannels, nchannels
+            data = np.frombuffer(mapped_data, dtype).reshape(
+                plain_shape[0], array_stride, nchannels
             )
             data = data[:, : plain_shape[1], :]
 
@@ -628,3 +602,50 @@ class AsyncImageDownloadAction:
             raise RuntimeError(f"Unknown present submethod {submethod!r}")
 
         return data
+
+
+FORMAT_CACHE = {}  # wgpu.TextureFormat -> (dtype, short-format, nchannels, bytes_per_pixel)
+
+
+def parse_format(format: str) -> tuple[str, str, int, int]:
+    """Parse a wgpu TextureFormat, using a cache."""
+
+    try:
+        return FORMAT_CACHE[format]
+    except KeyError:
+        pass
+
+    if format.startswith(("rgba", "bgra")):
+        nchannels = 4
+    else:
+        raise RuntimeError(f"Image present unsupported texture format {format}.")
+    if "8" in format:
+        bytes_per_pixel = nchannels
+    elif "16" in format:
+        bytes_per_pixel = nchannels * 2
+    elif "32" in format:
+        bytes_per_pixel = nchannels * 4
+    else:
+        raise RuntimeError(
+            f"Image present unsupported texture format bitdepth {format}."
+        )
+
+    if "float" in format:
+        dtype = "float16" if "16" in format else "float32"
+    else:
+        dtype = "int" if "sint" in format else "uint"
+        if "32" in format:
+            dtype += "32"
+        elif "16" in format:
+            dtype += "16"
+        else:
+            dtype += "8"
+
+    short_dtype = dtype
+    for s1, s2 in [("float", "f"), ("uint", "u"), ("int", "i")]:
+        short_dtype = short_dtype.replace(s1, s2)
+    short_format = format[:4] + "-" + short_dtype
+
+    result = dtype, short_format, nchannels, bytes_per_pixel
+    FORMAT_CACHE[format] = result
+    return result

--- a/rendercanvas/contexts/wgpucontext.py
+++ b/rendercanvas/contexts/wgpucontext.py
@@ -446,6 +446,7 @@ class ImageDownloader:
             "bytes_per_row": stride,
             "rows_per_image": texture.size[1],
         }
+
         # Copy data to temp buffer
         encoder = self._device.create_command_encoder()
         encoder.copy_texture_to_buffer(source, destination, texture.size)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,7 +19,7 @@ def get_test_bitmap(width, height):
         (0, 0, 255, 255),
         (0, 0, 0, 255),
         (50, 50, 50, 255),
-        (127, 127, 127, 255),
+        (128, 128, 128, 255),
         (205, 205, 205, 255),
         (255, 255, 255, 255),
     ]
@@ -266,6 +266,7 @@ def test_wgpu_context():
     result = canvas.draw()
 
     assert isinstance(result, np.ndarray)
+    assert result.dtype == np.uint8
     assert np.all(result == bitmap)
 
     # Now we change the size
@@ -277,6 +278,22 @@ def test_wgpu_context():
     assert result.shape != bitmap.shape
     assert result.shape[1] == canvas.get_physical_size()[0]
     assert result.shape[0] == canvas.get_physical_size()[1]
+
+
+@pytest.mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_wgpu_context_hdr():
+    # Create canvas with float16 texture format
+    canvas = ManualOffscreenRenderCanvas(format="rgba-f16")
+    context = canvas.get_context(BitmapContextToWgpuAndBackToBitmap)
+
+    bitmap = get_test_bitmap(*canvas.get_physical_size())
+    context.set_bitmap(bitmap)
+    result = canvas.draw()
+
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.float16
+    assert result.shape == bitmap.shape
+    assert np.all(result * 255 == bitmap)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes this wgpu example: https://github.com/pygfx/wgpu-py/blob/main/examples/offscreen_hdr.py

cc @Vipitis 

* [x] Fix that the returned bitmap download dict had the format hardcoded to 'rgba-u8' instead of using the actual format.
* [x] Fix the conversion of the buffer bytes to a numpy array, for formats other than u8.
* [x] Performance improvement by caching the parsing of the texture format. 
* [x] Add a test to avoid regression. 

----

The wgpu-py example now produces a nice cube:

<img width="1155" height="850" alt="image" src="https://github.com/user-attachments/assets/bb48ddaa-ff25-4bde-8f99-0437a5eced60" />
