### PR TITLE
Add terminal backend

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -57,6 +57,11 @@ The table below gives an overview of the names in the different ``rendercanvas``
           | ``loop`` (an ``AsyncioLoop``)
         - | Backend when Python is running in the browser,
           | via Pyodide or PyScript.
+    *   - ``terminal``
+        - | ``TerminalRenderCanvas``
+          | ``RenderCanvas`` (alias)
+          | ``loop`` (an ``AsyncioLoop``)
+        - | Render in the terminal (using ``blessed``).
 
 There are also three loop-backends. These are mainly intended for use with the glfw backend:
 

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -41,6 +41,11 @@ The table below gives an overview of the names in the different ``rendercanvas``
           | ``RenderCanvas`` (alias)
           | ``loop`` (a ``StubLoop``)
         - | For offscreen rendering.
+    *   - ``terminal``
+        - | ``TerminalRenderCanvas``
+          | ``RenderCanvas`` (alias)
+          | ``loop`` (an ``AsyncioLoop``)
+        - | Render in the terminal.
     *   - ``http``
         - | ``HttpRenderCanvas``
           | ``RenderCanvas`` (alias)
@@ -64,11 +69,7 @@ The table below gives an overview of the names in the different ``rendercanvas``
           | ``loop`` (an ``AsyncioLoop``)
         - | Backend when Python is running in the
           | browser via Pyodide or PyScript.
-    *   - ``terminal``
-        - | ``TerminalRenderCanvas``
-          | ``RenderCanvas`` (alias)
-          | ``loop`` (an ``AsyncioLoop``)
-        - | Render in the terminal (using ``blessed``).
+
 
 There are also three loop-backends. These are mainly intended for use with the glfw backend:
 
@@ -284,6 +285,22 @@ object, but in some cases it's convenient to do so with a canvas-like API.
     array = canvas.draw()  # numpy array with shape (400, 500, 4)
 
 
+Support for the terminal
+------------------------
+
+You can also render directly to the terminal. There are some limitations, and the pixels are huge, but can be great for quick inspections or to impress people.
+
+It can be run with any render-canvas based application that uses the auto backend:
+
+.. code-block:: bash
+
+    $ RENDERCANVAS_BACKEND=terminal python my_app.py
+
+
+.. autoclass:: rendercanvas.terminal.TerminalRenderCanvas
+    :members:
+
+
 Support for http / web (experimental)
 -------------------------------------
 
@@ -451,6 +468,8 @@ Similar as with PyScript, you can chose between a ``<canvas>``  and a ``<div cla
 
 
 .. _env_vars:
+
+
 
 Selecting a backend with env vars
 ---------------------------------

--- a/examples/cube_auto.py
+++ b/examples/cube_auto.py
@@ -7,7 +7,7 @@ Run a wgpu example on an automatically selected backend.
 
 # run_example = true
 
-from rendercanvas.auto import RenderCanvas, loop
+from rendercanvas.terminal import RenderCanvas, loop
 from rendercanvas.utils.cube import setup_drawing_sync
 
 canvas = RenderCanvas(

--- a/examples/cube_auto.py
+++ b/examples/cube_auto.py
@@ -7,7 +7,7 @@ Run a wgpu example on an automatically selected backend.
 
 # run_example = true
 
-from rendercanvas.terminal import RenderCanvas, loop
+from rendercanvas.auto import RenderCanvas, loop
 from rendercanvas.utils.cube import setup_drawing_sync
 
 canvas = RenderCanvas(

--- a/examples/snake.py
+++ b/examples/snake.py
@@ -21,10 +21,19 @@ canvas = RenderCanvas(
 
 context = canvas.get_bitmap_context()
 
-world = np.zeros((120, 160), np.uint8)
+world = np.zeros((60, 80), np.uint8)
 pos = [100, 100]
 direction = [1, 0]
 q = deque()
+
+
+@canvas.add_event_handler("resize")
+def on_resize(event):
+    # Match the size of the canvas, with an 8-fold reduction to get massive pixels.
+    # Incidentally, this results in precise physical pixels for the terminal backend :)
+    global world
+    w, h = int(event["width"]) // 8, int(event["height"]) // 8
+    world = np.zeros((h, w, 4), np.uint8)
 
 
 @canvas.add_event_handler("key_down")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,24 @@ glfw = ["glfw>=1.9"]
 terminal = ["blessed"]
 # For devs / ci
 lint = ["ruff", "pre-commit"]
-examples = ["flit", "numpy", "wgpu", "glfw", "pyside6", "imageio", "pytest"]
-docs = ["flit", "sphinx>7.2", "sphinx_rtd_theme", "sphinx-gallery", "wgpu"]
+examples = [
+    "flit",
+    "numpy",
+    "wgpu",
+    "glfw",
+    "pyside6",
+    "imageio",
+    "pytest",
+    "blessed",
+]
+docs = [
+    "flit",
+    "sphinx>7.2",
+    "sphinx_rtd_theme",
+    "sphinx-gallery",
+    "wgpu",
+    "blessed",
+]
 tests = [
     "pytest",
     "wgpu",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = ["numpy"] # Numpy is the only hard dependency
 jupyter = ["jupyter_rfb>=0.4.2", "simplejpeg; implementation_name != 'pypy'"]
 notebook = ["anywidget", "simplejpeg; implementation_name != 'pypy'"]
 glfw = ["glfw>=1.9"]
+terminal = ["blessed"]
 # For devs / ci
 lint = ["ruff", "pre-commit"]
 examples = ["flit", "numpy", "wgpu", "glfw", "pyside6", "imageio", "pytest"]

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -150,7 +150,6 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         self._upscale_factor = max(1, int(upscale_factor))
 
         self._closed = False
-        self._title = ""
         self._term_size = 0, 0
         self._pointer_pos = (0, 0)
         self._pointer_buttons = ()
@@ -166,7 +165,6 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         term_size = term.width, term.height
         if term_size != self._term_size:
             self._term_size = term_size
-            self._set_clipped_title()
             # Determine physical size. Each char is two vertical pixels. Have a margin to avoid jump artifacts.
             pwidth = term_size[0] * self._upscale_factor
             pheight = term_size[1] * 2 * self._upscale_factor
@@ -299,13 +297,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             term_stream.write(term.move_xy(0, y // 2) + line)
             # Show title and close button on the first line. Do here to avoid flicker.
             if y == 0:
-                term_stream.write(
-                    term.normal
-                    + term.move_xy(0, 0)
-                    + self._clipped_title
-                    + term.move_xy(img.shape[1] - 1, 0)
-                    + "×"  # noqa: RUF001
-                )
+                term_stream.write(term.normal + term.move_xy(img.shape[1] - 1, 0) + "×")  # noqa: RUF001
 
         # Reset and flush. Moving to (0, 0) prevents jump-flicker by avoiding the jump to the *next* line.
         term_stream.write(term.normal + term.move_xy(0, 0) + "\n")
@@ -321,15 +313,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         return self._closed
 
     def _rc_set_title(self, title):
-        self._title = title
-        self._set_clipped_title()
-
-    def _set_clipped_title(self):
-        w = max(2, self._term_size[0] - 3)
-        if len(self._title) > w:
-            self._clipped_title = self._title[: w - 1] + "…"
-        else:
-            self._clipped_title = self._title
+        term_stream.write(term.set_window_title(title) + "\n")
 
     def _rc_set_cursor(self, cursor):
         pass

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -416,7 +416,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 overlay_builder.add_button("collapse_menu", "▴")  # ▲▴
             else:
                 overlay_builder.add_button("expand_menu", "▾")  # ▼▾
-            overlay_builder.add_button("close", "×")  # noqa: RUF001  - ×✕✖
+            overlay_builder.add_button("close", "×")  # noqa: RUF001
             return overlay_builder.get_line(align_right=width)
         elif self._expanded_menu:
             if y == 2:

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -39,6 +39,18 @@ def captured_stdout_and_stderr():
         original_stderr.write(buf_err.getvalue())
 
 
+@contextmanager
+def set_pointer_to_arrow():
+    does_pointer = term.does_kitty_pointer_shapes()
+    if does_pointer:
+        sys.stdout.write("\033]22;default\007")  # arrow pointer
+    try:
+        yield
+    finally:
+        if does_pointer:
+            sys.stdout.write("\033]22;\007")  # reset to terminal default
+
+
 KEY_MAP = {
     "KEY_DOWN": "ArrowDown",
     "KEY_UP": "ArrowUp",
@@ -88,6 +100,7 @@ class TerminalLoop(AsyncioLoop):
             term.hidden_cursor(),
             term.cbreak(),
             term.mouse_enabled(report_motion=True),
+            set_pointer_to_arrow(),
         ):
             super()._rc_run()
 
@@ -156,9 +169,9 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         elif keystroke.name and keystroke.name.startswith("MOUSE_"):
             key_name = keystroke.name
             # Get pos
-            x, y = keystroke.mouse_xy
-            x = float(x) / self._pixel_ratio
-            y = float(y) * 2 / self._pixel_ratio
+            term_x, term_y = keystroke.mouse_xy
+            x = float(term_x) / self._pixel_ratio
+            y = float(term_y) * 2 / self._pixel_ratio
             self._pointer_pos = x, y
             # Get kind
             if "MOTION" in key_name:
@@ -181,6 +194,14 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             modifiers = []
             if "SHIFT" in key_name:
                 modifiers.append("Shift")
+            # Exit when the cross in the top-right is clicked
+            if (
+                kind == "down"
+                and button == 1
+                and term_y == 0
+                and term_x == self._term_size[0] - 1
+            ):
+                loop.stop()
             # Submit!
             ev = {
                 "event_type": f"pointer_{kind}",
@@ -194,9 +215,9 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             }
             self.submit_event(ev)
         else:
-            # TODO: Exit? Since there is no close button, allow exit with ESCAPE in addition to CTRL-C?
-            if keystroke.key_name == "KEY_ESCAPE":
-                loop.stop()
+            # The application exits on Control-C, we could also exit on escape, but escape may be an application event.
+            # if keystroke.key_name == "KEY_ESCAPE":
+            #     loop.stop()
             # Get key
             if keystroke.key_name:
                 key = KEY_MAP.get(keystroke.key_name, "")
@@ -255,8 +276,13 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             term_stream.write(line)
 
         # Reset and flush. Moving to (0, 0) prevents flicker by avoiding the jump to the *next* line.
-        term_stream.write(term.move_xy(0, im.shape[1] - 1) + term.normal + "X")
-        term_stream.write(term.move_xy(0, 0) + "\n")
+        term_stream.write(
+            term.move_xy(img.shape[1] - 1, 0)
+            + term.on_color_rgb(0, 0, 0)
+            + term.color_rgb(255, 255, 255)
+            + "×"
+        )
+        term_stream.write(term.move_xy(0, 0) + term.normal + "\n")
         term_stream.flush()
 
     def _rc_set_logical_size(self, width, height):

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -127,7 +127,7 @@ class TerminalCanvasGroup(BaseCanvasGroup):
 
 
 class TerminalRenderCanvas(BaseRenderCanvas):
-    """A canvas that enders in the terminal.
+    """A canvas that renders in the terminal.
 
     Arguments:
         pixel_ratio : float

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -111,11 +111,16 @@ class TerminalRenderCanvas(BaseRenderCanvas):
 
         self._closed = False
         self._term_size = 0, 0
+        self._pointer_pos = (0, 0)
+        self._pointer_buttons = ()
 
         # TODO: force singleton
 
         self._rc_gui_poll()
         self._final_canvas_init()
+
+        # Start with a pointer enter event
+        self.submit_event({"event_type": "pointer_enter"})
 
     def _rc_gui_poll(self):
         # Check for resize
@@ -132,12 +137,29 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         keystroke = term.inkey(timeout=0)
         if not keystroke:
             pass
+        elif keystroke.name and keystroke.name.startswith("MOUSE_SCROLL_"):
+            delta = 200  # empirically determined. Can adjust.
+            if keystroke.name.endswith("UP"):
+                delta = -delta
+            ev = {
+                "event_type": "wheel",
+                "dx": 0,
+                "dy": delta,
+                "x": self._pointer_pos[0],
+                "y": self._pointer_pos[1],
+                "buttons": tuple(self._pointer_buttons),
+                "modifiers": tuple(),
+            }
+            print(ev)
+            self.submit_event(ev)
+
         elif keystroke.name and keystroke.name.startswith("MOUSE_"):
             key_name = keystroke.name
             # Get pos
-            x, y = keystroke.mouse_yx
-            x = float(x) * self._pixel_ratio
-            y = float(y) * 2 * self._pixel_ratio
+            x, y = keystroke.mouse_xy
+            x = float(x) / self._pixel_ratio
+            y = float(y) * 2 / self._pixel_ratio
+            self._pointer_pos = x, y
             # Get kind
             if "MOTION" in key_name:
                 kind = "move"
@@ -154,6 +176,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             elif "MIDDLE" in key_name:
                 button = 3
             buttons = () if kind == "up" else (button,)
+            self._pointer_buttons = buttons
             # Modifiers
             modifiers = []
             if "SHIFT" in key_name:

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -125,6 +125,11 @@ class TerminalLoop(AsyncioLoop):
         ):
             super()._rc_run()
 
+            # Flush events, to drain stdin, to prevent weird numbers on the prompt.
+            # This needs to happen *before* the finalizers of mouse_enabled and enable_kitty_keyboard.
+            while term.inkey(timeout=0):
+                pass
+
 
 loop = TerminalLoop()
 

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -1,0 +1,134 @@
+"""
+A stub backend for documentation purposes.
+"""
+
+__all__ = ["RenderCanvas", "TerminalRenderCanvas", "loop"]
+
+
+import sys
+
+from .base import BaseCanvasGroup, BaseRenderCanvas
+from .asyncio import AsyncioLoop
+
+import numpy as np
+
+# The terminal backend requires the blessed library, which is simple and has few dependencies
+import blessed
+
+
+term = blessed.Terminal()
+
+
+class TerminalLoop(AsyncioLoop):
+    def _rc_run(self):
+        with term.fullscreen(), term.hidden_cursor():
+            super()._rc_run()
+
+
+loop = TerminalLoop()
+
+
+class TerminalCanvasGroup(BaseCanvasGroup):
+    pass
+
+
+class TerminalRenderCanvas(BaseRenderCanvas):
+    """A canvas in the terminal, using blessed."""
+
+    _rc_canvas_group = TerminalCanvasGroup(loop)
+
+    def __init__(self, *args, pixel_ratio=0.25, upscale_factor=1, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._pixel_ratio = max(1 / 32, float(pixel_ratio))
+        self._upscale_factor = max(1, int(upscale_factor))
+
+        self._closed = False
+        self._term_size = 0, 0
+
+        # TODO: force singleton
+
+        self._rc_gui_poll()
+        self._final_canvas_init()
+
+    def _rc_gui_poll(self):
+        # Check for resize
+        term_size = term.width, term.height
+        if term_size != self._term_size:
+            self._term_size = term_size
+            # Determine physical size. Each char is two vertical pixels. Have a margin to avoid jump artifacts.
+            pwidth = term_size[0] * self._upscale_factor
+            pheight = term_size[1] * 2 * self._upscale_factor
+            self._size_info.set_physical_size(pwidth, pheight, self._pixel_ratio)
+            self.request_draw()
+
+        # Check for key pressed
+        key = term.inkey(timeout=0)
+        if key:
+            sys.stderr.write(key + "\n")
+
+    def _rc_get_present_info(self, present_methods):
+        if "bitmap" in present_methods:
+            return {
+                "method": "bitmap",
+                "formats": ["rgba-u8", "rgba-f16", "rgba-u16"],
+            }
+        else:
+            return None  # raises error
+
+    def _rc_request_draw(self):
+        self._time_to_draw()
+
+    def _rc_request_paint(self):
+        loop = self._rc_canvas_group.get_loop()
+        loop.call_soon(self._time_to_paint)
+
+    def _rc_force_paint(self):
+        self._time_to_paint()
+
+    def _rc_present_bitmap(self, *, data, format, **kwargs):
+        # Get image from data, optionally downscale
+        factor = self._upscale_factor
+        if factor == 1:
+            img = data
+        else:
+            h, w, c = data.shape
+            img = (
+                data.reshape(h // factor, factor, w // factor, factor, c)
+                .mean(axis=(1, 3))
+                .astype(np.uint8)
+            )
+
+        # Push lines to stdout
+        for y in range(0, img.shape[0], 2):
+            top_row = img[y][:, :3]
+            bot_row = img[y + 1][:, :3]
+            line = "".join(
+                term.on_color_rgb(*rgb1) + term.color_rgb(*rgb2) + "▄"
+                for rgb1, rgb2 in zip(top_row, bot_row, strict=True)
+            )
+            sys.stdout.write(term.move_xy(0, y // 2))
+            sys.stdout.write(line)
+
+        # Reset and flush. Moving to (0, 0) prevents flicker by avoiding the jump to the *next* line.
+        sys.stdout.write(term.move_xy(0, 0) + term.normal + "\n")
+        sys.stdout.flush()
+
+    def _rc_set_logical_size(self, width, height):
+        pass  # we ignore setting the size, we simply take the full size of the window
+
+    def _rc_close(self):
+        self._closed = True
+
+    def _rc_get_closed(self):
+        return self._closed
+
+    def _rc_set_title(self, title):
+        pass
+
+    def _rc_set_cursor(self, cursor):
+        pass
+
+
+# Make available under a common name
+loop = loop
+RenderCanvas = TerminalRenderCanvas

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -9,10 +9,13 @@ Support for rendering in a terminal session, using the blessed library.
 # they are subject to a 256 color palette, which can look bad, but also incurs
 # additional CPU processing.
 #
-# The key events are not great. Looks like with kitty keystrokes it can be
-# improved but I had limited success, so I decided to just keep it simple. The
-# pointer events are much better, but e.g. RMB and most modifier keys except shift
-# are consumed by the terminal app for context menu etc.
+# Support for modifiers is not great, because the terminal application usually
+# does something with Ctrl/Cmd, so we only really support the Shift modifier.
+#
+# Sometimes when the app exits, escape sequences are shown in the stdout or on
+# the prompt. We take measures to prevent this, but I still sometimes see it.
+# Important is to flush term_stream before restoring from full-screen, and flush
+# empty the stdin stream before restoring cbreak (and maybe others).
 
 __all__ = ["RenderCanvas", "TerminalRenderCanvas", "loop"]
 
@@ -142,11 +145,13 @@ class TerminalRenderCanvas(BaseRenderCanvas):
 
     Arguments:
         pixel_ratio : float
-            The (initial) ratio that determines the logical size of the window. Default 1/8; the pixels are huge!
+            The (initial) ratio that determines the logical size of the window. Default is 1/8
+
+    This backend depends on the ``blessed`` library.
 
     Restrictions of this backend:
 
-    * Obviously the resolution is very low: 2 pixels (vertically) per character.
+    * Obviously the resolution is very low: each terminal represents just two pixels (vertically).
     * Limited support for modifiers in pointer and key events (only Shift).
     * The experience may differ depending on the terminal you're at.
 

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -295,7 +295,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 for rgb1, rgb2 in zip(top_row, bot_row, strict=True)
             )
             term_stream.write(term.move_xy(0, y // 2) + line)
-            # Show title and close button on the first line. Do here to avoid flicker.
+            # Show close button on the first line. Do here rather then at end to avoid flicker.
             if y == 0:
                 term_stream.write(term.normal + term.move_xy(img.shape[1] - 1, 0) + "×")  # noqa: RUF001
 

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -112,6 +112,12 @@ class TerminalLoop(AsyncioLoop):
             term.fullscreen(),
             term.hidden_cursor(),
             captured_stdout_and_stderr(),
+            term.enable_kitty_keyboard(
+                report_events=True,
+                report_all_keys=True,
+                report_alternates=True,
+                report_text=True,
+            ),
             term.cbreak(),
             term.mouse_enabled(report_motion=True),
             set_pointer_to_arrow(),
@@ -136,9 +142,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
     Restrictions of this backend:
 
     * Obviously the resolution is very low: 2 pixels (vertically) per character.
-    * Only key_down events, no key_up.
-    * No support for modifiers with key events.
-    * Limited support for modifiers in pointer events (only Shift).
+    * Limited support for modifiers in pointer and key events (only Shift).
     * The experience may differ depending on the terminal you're at.
 
     """
@@ -156,6 +160,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         self._term_size = 0, 0
         self._pointer_pos = (0, 0)
         self._pointer_buttons = ()
+        self._pressed_keys = {}
 
         self._rc_gui_poll()
         self._final_canvas_init()
@@ -194,10 +199,15 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             self.request_draw()
 
         # Check for key/mouse pressed. Read buffered events until the buffer is empty.
-        while keystroke := term.inkey(timeout=0):
-            if keystroke.name and keystroke.name.startswith("MOUSE_SCROLL_"):
+        while True:
+            keystroke = term.inkey(timeout=0)
+            if not keystroke:
+                break
+            stroke_name = keystroke.name or ""
+
+            if stroke_name.startswith("MOUSE_SCROLL_"):
                 delta = 200  # empirically determined. Can adjust.
-                if keystroke.name.endswith("UP"):
+                if stroke_name.endswith("UP"):
                     delta = -delta
                 ev = {
                     "event_type": "wheel",
@@ -210,33 +220,32 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 }
                 self.submit_event(ev)
 
-            elif keystroke.name and keystroke.name.startswith("MOUSE_"):
-                key_name = keystroke.name
+            elif stroke_name.startswith("MOUSE_"):
                 # Get pos
                 term_x, term_y = keystroke.mouse_xy
                 x = float(term_x) / self._pixel_ratio
                 y = float(term_y) * 2 / self._pixel_ratio
                 self._pointer_pos = x, y
                 # Get kind
-                if "MOTION" in key_name:
+                if "MOTION" in stroke_name:
                     kind = "move"
-                elif "RELEASED" in key_name:
+                elif "RELEASED" in stroke_name:
                     kind = "up"
                 else:
                     kind = "down"
                 # Get button and buttons. We ignore that buttons can be clicked when other buttons are down
                 button = 0
-                if "LEFT" in key_name:
+                if "LEFT" in stroke_name:
                     button = 1
-                elif "RIGHT" in key_name:
+                elif "RIGHT" in stroke_name:
                     button = 2
-                elif "MIDDLE" in key_name:
+                elif "MIDDLE" in stroke_name:
                     button = 3
                 buttons = () if kind == "up" else (button,)
                 self._pointer_buttons = buttons
                 # Modifiers
                 modifiers = []
-                if "SHIFT" in key_name:
+                if "SHIFT" in stroke_name:
                     modifiers.append("Shift")
                 # Exit when the cross in the top-right is clicked
                 if (
@@ -266,20 +275,44 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 }
                 self.submit_event(ev)
             else:
+                key_name = keystroke.key_name
+                # self.set_title(
+                #     f"{stroke_name} | {key_name} | {keystroke.value!r}  repeated: {keystroke.repeated} pressed: {keystroke.pressed}"
+                # )
                 # The application exits on Control-C, we could also exit on escape, but escape may be an application event.
-                # if keystroke.key_name == "KEY_ESCAPE":
-                #     loop.stop()
+                if stroke_name == "KEY_CTRL_C":
+                    loop.stop()
                 # Get key
-                if keystroke.key_name:
-                    key = KEY_MAP.get(keystroke.key_name, "")
-                else:
+                if key_name:
+                    key = KEY_MAP.get(key_name, "")
+                if not key:
                     key = keystroke.value
-                # Submit event. Modifiers are tricky, I guess we ignore them
+                if not key:
+                    key = key_name.split("_")[-1].lower()
+                    if len(key) != 1:
+                        key = ""
+                # Modifiers
+                modifiers = []
+                if "SHIFT" in stroke_name:
+                    modifiers.append("Shift")
+                # Handle repeat and release
+                if keystroke.repeated:
+                    continue  # repeat for arrow keys etc.
+                elif keystroke.pressed and key:
+                    event_type = "key_down"
+                    if key_name in self._pressed_keys:
+                        continue  # repeat for character keys etc
+                    else:
+                        self._pressed_keys[key_name] = key
+                elif not keystroke.pressed:
+                    event_type = "key_up"
+                    key = self._pressed_keys.pop(key_name, None) or key
+                # Submit event
                 if key:
                     ev = {
-                        "event_type": "key_down",
+                        "event_type": event_type,
                         "key": key,
-                        "modifiers": tuple(),
+                        "modifiers": tuple(modifiers),
                     }
                     self.submit_event(ev)
 

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -47,7 +47,6 @@ def captured_stdout_and_stderr():
     try:
         yield
     finally:
-        term_stream.flush()
         sys.stdout = original_stdout
         sys.stderr = original_stderr
         original_stdout.write(buf_out.getvalue())
@@ -334,34 +333,51 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         self._time_to_paint()
 
     def _rc_present_bitmap(self, *, data, format, **kwargs):
+        # Note: y and h refer to physical pixels here, not term rows.
+        #
+        # Note: some terminals (seen on iterm) color their margin based on the
+        # bg of the edge chars, so pixels bleed into the margin. there is no
+        # clear solution except applying a margin of 1px on each side, so let it be.
+
+        term_w, term_h = self._term_size[0], self._term_size[1] * 2
+        data_h, data_w = data.shape[:2]
+
+        # Resize image if necessary
+        if term_w == data_w or term_h == data_h:
+            img = data
+        else:
+            img = resize_nearest(data, term_h, term_w)
+
         # Get 8bit image
         if format == "rgba-f16":
-            img = np.rint(data)
+            img = img * 255
+            np.rint(img, out=img)
             np.clip(img, 0, 255, out=img)
             img = img.astype(np.uint8)
         elif format == "rgba-u16":
-            img = data // 256
+            img = img // 256
             img = img.astype(np.uint8)
         else:  # format == "rgba-u8":
-            img = data
+            img = img
 
         self._overlay_builder = overlay_builder = OverlayBuilder()
 
         # Push lines to stdout
-        for y in range(0, img.shape[0], 2):
-            line_index = y // 2
-            top_row = img[y][:, :3]
-            bot_row = img[y + 1][:, :3]
+        for y in range(0, term_h, 2):
+            term_row = y // 2
+            top_row = img[y, :, :3]
+            bot_row = img[y + 1, :, :3]
             line = "".join(
                 term.on_color_rgb(*rgb1) + term.color_rgb(*rgb2) + "▄"
                 for rgb1, rgb2 in zip(top_row, bot_row, strict=True)
             )
-            term_stream.write(term.move_xy(0, line_index) + line)
+            term_stream.write(term.move_xy(0, term_row) + line)
+
             # Apply overlay directly at each line (rather than at the end) to avoid flicker
-            res = self._get_overlay(overlay_builder, line_index, img.shape[1])
+            res = self._get_overlay(overlay_builder, term_row, term_w)
             if res is not None:
                 offset, s = res
-                term_stream.write(term.normal + term.move_xy(offset, line_index) + s)
+                term_stream.write(term.normal + term.move_xy(offset, term_row) + s)
 
         # Reset and flush. Moving to (0, 0) prevents jump-flicker by avoiding the jump to the *next* line.
         term_stream.write(term.normal + term.move_xy(0, 0) + "\n")
@@ -478,6 +494,13 @@ class OverlayBuilder:
         for x1, x2, action in buttons:
             if x1 <= x <= x2:
                 return action
+
+
+def resize_nearest(img, new_h, new_w):
+    h, w = img.shape[:2]
+    y = (np.arange(new_h) * h / new_h).astype(int)
+    x = (np.arange(new_w) * w / new_w).astype(int)
+    return img[np.ix_(y, x)]
 
 
 # Make available under a common name

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -255,7 +255,8 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             term_stream.write(line)
 
         # Reset and flush. Moving to (0, 0) prevents flicker by avoiding the jump to the *next* line.
-        term_stream.write(term.move_xy(0, 0) + term.normal + "\n")
+        term_stream.write(term.move_xy(0, im.shape[1] - 1) + term.normal + "X")
+        term_stream.write(term.move_xy(0, 0) + "\n")
         term_stream.flush()
 
     def _rc_set_logical_size(self, width, height):

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -110,6 +110,9 @@ KEY_MAP = {
 
 
 class TerminalLoop(AsyncioLoop):
+
+    kitty_keyboard = None
+
     def _rc_run(self):
         with (
             captured_stdout_and_stderr(),  # must come first
@@ -125,6 +128,8 @@ class TerminalLoop(AsyncioLoop):
             term.mouse_enabled(report_motion=True),
             set_pointer_to_arrow(),
         ):
+            self.kitty_keyboard = term.get_kitty_keyboard_state()
+
             super()._rc_run()
 
             # Flush events, to drain stdin, to prevent weird numbers on the prompt.
@@ -285,8 +290,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 if stroke_name == "KEY_CTRL_C":
                     loop.stop()
                 # Get key
-                if key_name:
-                    key = KEY_MAP.get(key_name, "")
+                key = KEY_MAP.get(key_name, "")
                 if not key:
                     key = keystroke.value
                 if not key:
@@ -302,10 +306,11 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                     continue  # repeat for arrow keys etc.
                 elif keystroke.pressed and key:
                     event_type = "key_down"
-                    if key_name in self._pressed_keys:
-                        continue  # repeat for character keys etc
-                    else:
-                        self._pressed_keys[key_name] = key
+                    if loop.kitty_keyboard:
+                        if key_name in self._pressed_keys:
+                            continue  # repeat for character keys etc
+                        else:
+                            self._pressed_keys[key_name] = key
                 elif not keystroke.pressed:
                     event_type = "key_up"
                     key = self._pressed_keys.pop(key_name, None) or key

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -470,9 +470,9 @@ class OverlayBuilder:
         self.len = 0
         self.parts = []
 
-    def add_button(self, action, label):
-        text = f" [ {label} ]"
-        x1 = self.len + 1
+    def add_button(self, action, label, sep=" "):
+        text = f"{sep}[{label}]"
+        x1 = self.len + len(sep)
         x2 = self.len + len(text) - 1
         self.buttons_per_line[self.y].append((x1, x2, action))
         self.parts.append(text)

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -5,7 +5,9 @@ A stub backend for documentation purposes.
 __all__ = ["RenderCanvas", "TerminalRenderCanvas", "loop"]
 
 
+import io
 import sys
+from contextlib import contextmanager
 
 from .base import BaseCanvasGroup, BaseRenderCanvas
 from .asyncio import AsyncioLoop
@@ -15,13 +17,77 @@ import numpy as np
 # The terminal backend requires the blessed library, which is simple and has few dependencies
 import blessed
 
+term_stream = sys.__stdout__
+original_stdout = sys.stdout
+original_stderr = sys.stderr
 
-term = blessed.Terminal()
+term = blessed.Terminal(stream=term_stream)
+
+
+@contextmanager
+def captured_stdout_and_stderr():
+    buf_out = io.StringIO()
+    buf_err = io.StringIO()
+    sys.stdout = buf_out
+    sys.stderr = buf_err
+    try:
+        yield
+    finally:
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+        original_stdout.write(buf_out.getvalue())
+        original_stderr.write(buf_err.getvalue())
+
+
+KEY_MAP = {
+    "KEY_DOWN": "ArrowDown",
+    "KEY_UP": "ArrowUp",
+    "KEY_LEFT": "ArrowLeft",
+    "KEY_RIGHT": "ArrowRight",
+    "KEY_BACKSPACE": "Backspace",
+    "KEY_": "CapsLock",
+    "KEY_DELETE": "Delete",
+    "KEY_END": "End",
+    "KEY_ENTER": "Enter",  # aka return
+    "KEY_ESCAPE": "Escape",
+    "KEY_F1": "F1",
+    "KEY_F2": "F2",
+    "KEY_F3": "F3",
+    "KEY_F4": "F4",
+    "KEY_F5": "F5",
+    "KEY_F6": "F6",
+    "KEY_F7": "F7",
+    "KEY_F8": "F8",
+    "KEY_F9": "F9",
+    "KEY_F10": "F10",
+    "KEY_F11": "F11",
+    "KEY_F12": "F12",
+    "KEY_HOME": "Home",
+    "KEY_INSERT": "Insert",
+    "KEY_ALT": "Alt",
+    # "KEY_CONTROL": "Control",
+    "KEY_COMMAND": "Control",
+    # "KEY_SHIFT": "Shift",
+    # "KEY_META": "Meta",
+    "KEY_NUM_LOCK": "NumLock",
+    "KEY_PGDOWN": "PageDown",
+    "KEY_PGUP": "PageUp",
+    "KEY_PAUSE": "Pause",
+    "KEY_PRINT_SCREEN": "PrintScreen",
+    # "KEY_ALT": "Alt",
+    "KEY_SCROLL_LOCK": "ScrollLock",
+    "KEY_TAB": "Tab",
+}
 
 
 class TerminalLoop(AsyncioLoop):
     def _rc_run(self):
-        with term.fullscreen(), term.hidden_cursor():
+        with (
+            captured_stdout_and_stderr(),
+            term.fullscreen(),
+            term.hidden_cursor(),
+            term.cbreak(),
+        ):
             super()._rc_run()
 
 
@@ -62,9 +128,24 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             self.request_draw()
 
         # Check for key pressed
-        key = term.inkey(timeout=0)
-        if key:
-            sys.stderr.write(key + "\n")
+        keystroke = term.inkey(timeout=0)
+        if keystroke:
+            # TODO: Exit? Since there is no close button, allow exit with ESCAPE in addition to CTRL-C?
+            if keystroke.key_name == "KEY_ESCAPE":
+                loop.stop()
+            # Get key
+            if keystroke.key_name:
+                key = KEY_MAP.get(keystroke.key_name, "")
+            else:
+                key = keystroke.value
+            # Submit event. Modifiers are tricky, I guess we ignore them
+            if key:
+                ev = {
+                    "event_type": "key_down",
+                    "key": key,
+                    "modifiers": (),
+                }
+                self.submit_event(ev)
 
     def _rc_get_present_info(self, present_methods):
         if "bitmap" in present_methods:
@@ -106,12 +187,12 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 term.on_color_rgb(*rgb1) + term.color_rgb(*rgb2) + "▄"
                 for rgb1, rgb2 in zip(top_row, bot_row, strict=True)
             )
-            sys.stdout.write(term.move_xy(0, y // 2))
-            sys.stdout.write(line)
+            term_stream.write(term.move_xy(0, y // 2))
+            term_stream.write(line)
 
         # Reset and flush. Moving to (0, 0) prevents flicker by avoiding the jump to the *next* line.
-        sys.stdout.write(term.move_xy(0, 0) + term.normal + "\n")
-        sys.stdout.flush()
+        term_stream.write(term.move_xy(0, 0) + term.normal + "\n")
+        term_stream.flush()
 
     def _rc_set_logical_size(self, width, height):
         pass  # we ignore setting the size, we simply take the full size of the window

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -129,7 +129,11 @@ class TerminalCanvasGroup(BaseCanvasGroup):
 class TerminalRenderCanvas(BaseRenderCanvas):
     """A canvas that enders in the terminal.
 
-    Restrictions:
+    Arguments:
+        pixel_ratio : float
+            The (initial) ratio that determines the logical size of the window. Default 0.25; the pixels are huge!
+
+    Restrictions of this backend:
 
     * Obviously the resolution is very low: 2 pixels (vertically) per character.
     * Only key_down events, no key_up.
@@ -141,13 +145,12 @@ class TerminalRenderCanvas(BaseRenderCanvas):
 
     _rc_canvas_group = TerminalCanvasGroup(loop)
 
-    def __init__(self, *args, pixel_ratio=0.25, upscale_factor=1, **kwargs):
+    def __init__(self, *args, pixel_ratio=0.25, **kwargs):
         super().__init__(*args, **kwargs)
 
         # NOTE: it is assumed that there is exactly one canvas. If this assumption is violated I guess they will alternately flicker.
 
-        self._pixel_ratio = max(1 / 32, float(pixel_ratio))
-        self._upscale_factor = max(1, int(upscale_factor))
+        self._pixel_ratio = pixel_ratio
 
         self._closed = False
         self._term_size = 0, 0
@@ -160,14 +163,33 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         # Start with a pointer enter event
         self.submit_event({"event_type": "pointer_enter"})
 
+    def set_pixel_ratio(self, pixel_ratio: float):
+        """Set the pixel ratio, changing the logical size of the canvas.
+
+        Since each character represents only 2 (vertical) pixels, the total
+        number of pixels is very small. A pixel_ratio of 1/8 is likely most
+        realistic (since text chars are typically 8 pixels wide). However, to be
+        able to read any rendered text you'll want a pixel_ratio of about 1, but
+        then the visualization may appear very much zoomed in. In other words,
+        the optimal pixel ratio for the terminal backend depends on the
+        application.
+
+        Therefore, the pixel ratio can be changed using a button at the
+        top-right of the screen, or programmatically using this method.
+        """
+        self._pixel_ratio = float(pixel_ratio)
+        pwidth, pheight = self.get_physical_size()
+        self._size_info.set_physical_size(pwidth, pheight, self._pixel_ratio)
+        self.request_draw()
+
     def _rc_gui_poll(self):
         # Check for resize
         term_size = term.width, term.height
         if term_size != self._term_size:
             self._term_size = term_size
             # Determine physical size. Each char is two vertical pixels. Have a margin to avoid jump artifacts.
-            pwidth = term_size[0] * self._upscale_factor
-            pheight = term_size[1] * 2 * self._upscale_factor
+            pwidth = term_size[0]
+            pheight = term_size[1] * 2
             self._size_info.set_physical_size(pwidth, pheight, self._pixel_ratio)
             self.request_draw()
 
@@ -221,9 +243,16 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                     kind == "down"
                     and button == 1
                     and term_y == 0
-                    and term_x == self._term_size[0] - 1
+                    and term_x >= self._term_size[0] - 4
                 ):
-                    loop.stop()
+                    if term_x == self._term_size[0] - 4:
+                        p = round(np.log2(self._pixel_ratio))
+                        self.set_pixel_ratio(2 ** (p - 1))
+                    elif term_x == self._term_size[0] - 3:
+                        p = round(np.log2(self._pixel_ratio))
+                        self.set_pixel_ratio(2 ** (p + 1))
+                    elif term_x == self._term_size[0] - 1:
+                        loop.stop()
                 # Submit!
                 ev = {
                     "event_type": f"pointer_{kind}",
@@ -274,17 +303,16 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         self._time_to_paint()
 
     def _rc_present_bitmap(self, *, data, format, **kwargs):
-        # Get image from data, optionally downscale
-        factor = self._upscale_factor
-        if factor == 1:
+        # Get 8bit image
+        if format == "rgba-f16":
+            img = np.rint(data)
+            np.clip(img, 0, 255, out=img)
+            img = img.astype(np.uint8)
+        elif format == "rgba-u16":
+            img = data // 256
+            img = img.astype(np.uint8)
+        else:  # format == "rgba-u8":
             img = data
-        else:
-            h, w, c = data.shape
-            img = (
-                data.reshape(h // factor, factor, w // factor, factor, c)
-                .mean(axis=(1, 3))
-                .astype(np.uint8)
-            )
 
         # Push lines to stdout
         for y in range(0, img.shape[0], 2):
@@ -297,7 +325,10 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             term_stream.write(term.move_xy(0, y // 2) + line)
             # Show close button on the first line. Do here rather then at end to avoid flicker.
             if y == 0:
-                term_stream.write(term.normal + term.move_xy(img.shape[1] - 1, 0) + "×")  # noqa: RUF001
+                s = f"ratio {self._pixel_ratio:0.4g} -+ ×"  # noqa: RUF001
+                term_stream.write(
+                    term.normal + term.move_xy(img.shape[1] - len(s), 0) + s
+                )
 
         # Reset and flush. Moving to (0, 0) prevents jump-flicker by avoiding the jump to the *next* line.
         term_stream.write(term.normal + term.move_xy(0, 0) + "\n")

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -1,6 +1,18 @@
 """
-A stub backend for documentation purposes.
+Support for rendering in a terminal session, using the blessed library.
 """
+
+# Dev notes:
+#
+# I've chosen to use the half-block rendering approach to increase the vertical
+# resolution and have more or less square pixels. I've not used sixels, since
+# they are subject to a 256 color palette, which can look bad, but also incurs
+# additional CPU processing.
+#
+# The key events are not great. Looks like with kitty keystrokes it can be
+# improved but I had limited success, so I decided to just keep it simple. The
+# pointer events are much better, but e.g. RMB and most modifier keys except shift
+# are consumed by the terminal app for context menu etc.
 
 __all__ = ["RenderCanvas", "TerminalRenderCanvas", "loop"]
 
@@ -13,14 +25,15 @@ from .base import BaseCanvasGroup, BaseRenderCanvas
 from .asyncio import AsyncioLoop
 
 import numpy as np
-
-# The terminal backend requires the blessed library, which is simple and has few dependencies
 import blessed
 
+
+# Store streams
 term_stream = sys.__stdout__
 original_stdout = sys.stdout
 original_stderr = sys.stderr
 
+# Blessed exposes all it's API via a single terminal object
 term = blessed.Terminal(stream=term_stream)
 
 
@@ -33,6 +46,7 @@ def captured_stdout_and_stderr():
     try:
         yield
     finally:
+        term_stream.flush()
         sys.stdout = original_stdout
         sys.stderr = original_stderr
         original_stdout.write(buf_out.getvalue())
@@ -95,9 +109,9 @@ KEY_MAP = {
 class TerminalLoop(AsyncioLoop):
     def _rc_run(self):
         with (
-            captured_stdout_and_stderr(),
             term.fullscreen(),
             term.hidden_cursor(),
+            captured_stdout_and_stderr(),
             term.cbreak(),
             term.mouse_enabled(report_motion=True),
             set_pointer_to_arrow(),
@@ -113,21 +127,33 @@ class TerminalCanvasGroup(BaseCanvasGroup):
 
 
 class TerminalRenderCanvas(BaseRenderCanvas):
-    """A canvas in the terminal, using blessed."""
+    """A canvas that enders in the terminal.
+
+    Restrictions:
+
+    * Obviously the resolution is very low: 2 pixels (vertically) per character.
+    * Only key_down events, no key_up.
+    * No support for modifiers with key events.
+    * Limited support for modifiers in pointer events (only Shift).
+    * The experience may differ depending on the terminal you're at.
+
+    """
 
     _rc_canvas_group = TerminalCanvasGroup(loop)
 
     def __init__(self, *args, pixel_ratio=0.25, upscale_factor=1, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # NOTE: it is assumed that there is exactly one canvas. If this assumption is violated I guess they will alternately flicker.
+
         self._pixel_ratio = max(1 / 32, float(pixel_ratio))
         self._upscale_factor = max(1, int(upscale_factor))
 
         self._closed = False
+        self._title = ""
         self._term_size = 0, 0
         self._pointer_pos = (0, 0)
         self._pointer_buttons = ()
-
-        # TODO: force singleton
 
         self._rc_gui_poll()
         self._final_canvas_init()
@@ -140,97 +166,95 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         term_size = term.width, term.height
         if term_size != self._term_size:
             self._term_size = term_size
+            self._set_clipped_title()
             # Determine physical size. Each char is two vertical pixels. Have a margin to avoid jump artifacts.
             pwidth = term_size[0] * self._upscale_factor
             pheight = term_size[1] * 2 * self._upscale_factor
             self._size_info.set_physical_size(pwidth, pheight, self._pixel_ratio)
             self.request_draw()
 
-        # Check for key/mouse pressed
-        keystroke = term.inkey(timeout=0)
-        if not keystroke:
-            pass
-        elif keystroke.name and keystroke.name.startswith("MOUSE_SCROLL_"):
-            delta = 200  # empirically determined. Can adjust.
-            if keystroke.name.endswith("UP"):
-                delta = -delta
-            ev = {
-                "event_type": "wheel",
-                "dx": 0,
-                "dy": delta,
-                "x": self._pointer_pos[0],
-                "y": self._pointer_pos[1],
-                "buttons": tuple(self._pointer_buttons),
-                "modifiers": tuple(),
-            }
-            print(ev)
-            self.submit_event(ev)
-
-        elif keystroke.name and keystroke.name.startswith("MOUSE_"):
-            key_name = keystroke.name
-            # Get pos
-            term_x, term_y = keystroke.mouse_xy
-            x = float(term_x) / self._pixel_ratio
-            y = float(term_y) * 2 / self._pixel_ratio
-            self._pointer_pos = x, y
-            # Get kind
-            if "MOTION" in key_name:
-                kind = "move"
-            elif "RELEASED" in key_name:
-                kind = "up"
-            else:
-                kind = "down"
-            # Get button and buttons. We ignore that buttons can be clicked when other buttons are down
-            button = 0
-            if "LEFT" in key_name:
-                button = 1
-            elif "RIGHT" in key_name:
-                button = 2
-            elif "MIDDLE" in key_name:
-                button = 3
-            buttons = () if kind == "up" else (button,)
-            self._pointer_buttons = buttons
-            # Modifiers
-            modifiers = []
-            if "SHIFT" in key_name:
-                modifiers.append("Shift")
-            # Exit when the cross in the top-right is clicked
-            if (
-                kind == "down"
-                and button == 1
-                and term_y == 0
-                and term_x == self._term_size[0] - 1
-            ):
-                loop.stop()
-            # Submit!
-            ev = {
-                "event_type": f"pointer_{kind}",
-                "x": x,
-                "y": y,
-                "button": button,
-                "buttons": buttons,
-                "modifiers": tuple(modifiers),
-                "ntouches": 0,
-                "touches": {},
-            }
-            self.submit_event(ev)
-        else:
-            # The application exits on Control-C, we could also exit on escape, but escape may be an application event.
-            # if keystroke.key_name == "KEY_ESCAPE":
-            #     loop.stop()
-            # Get key
-            if keystroke.key_name:
-                key = KEY_MAP.get(keystroke.key_name, "")
-            else:
-                key = keystroke.value
-            # Submit event. Modifiers are tricky, I guess we ignore them
-            if key:
+        # Check for key/mouse pressed. Read buffered events until the buffer is empty.
+        while keystroke := term.inkey(timeout=0):
+            if keystroke.name and keystroke.name.startswith("MOUSE_SCROLL_"):
+                delta = 200  # empirically determined. Can adjust.
+                if keystroke.name.endswith("UP"):
+                    delta = -delta
                 ev = {
-                    "event_type": "key_down",
-                    "key": key,
+                    "event_type": "wheel",
+                    "dx": 0,
+                    "dy": delta,
+                    "x": self._pointer_pos[0],
+                    "y": self._pointer_pos[1],
+                    "buttons": tuple(self._pointer_buttons),
                     "modifiers": tuple(),
                 }
                 self.submit_event(ev)
+
+            elif keystroke.name and keystroke.name.startswith("MOUSE_"):
+                key_name = keystroke.name
+                # Get pos
+                term_x, term_y = keystroke.mouse_xy
+                x = float(term_x) / self._pixel_ratio
+                y = float(term_y) * 2 / self._pixel_ratio
+                self._pointer_pos = x, y
+                # Get kind
+                if "MOTION" in key_name:
+                    kind = "move"
+                elif "RELEASED" in key_name:
+                    kind = "up"
+                else:
+                    kind = "down"
+                # Get button and buttons. We ignore that buttons can be clicked when other buttons are down
+                button = 0
+                if "LEFT" in key_name:
+                    button = 1
+                elif "RIGHT" in key_name:
+                    button = 2
+                elif "MIDDLE" in key_name:
+                    button = 3
+                buttons = () if kind == "up" else (button,)
+                self._pointer_buttons = buttons
+                # Modifiers
+                modifiers = []
+                if "SHIFT" in key_name:
+                    modifiers.append("Shift")
+                # Exit when the cross in the top-right is clicked
+                if (
+                    kind == "down"
+                    and button == 1
+                    and term_y == 0
+                    and term_x == self._term_size[0] - 1
+                ):
+                    loop.stop()
+                # Submit!
+                ev = {
+                    "event_type": f"pointer_{kind}",
+                    "x": x,
+                    "y": y,
+                    "button": button,
+                    "buttons": buttons,
+                    "modifiers": tuple(modifiers),
+                    "ntouches": 0,
+                    "touches": {},
+                }
+                self.submit_event(ev)
+            else:
+                # The application exits on Control-C, we could also exit on escape, but escape may be an application event.
+                # if keystroke.key_name == "KEY_ESCAPE":
+                #     loop.stop()
+                # Get key
+                if keystroke.key_name:
+                    key = KEY_MAP.get(keystroke.key_name, "")
+                else:
+                    key = keystroke.value
+                # Submit event. Modifiers are tricky, I guess we ignore them
+                if key:
+                    ev = {
+                        "event_type": "key_down",
+                        "key": key,
+                        "modifiers": tuple(),
+                    }
+                    self.submit_event(ev)
 
     def _rc_get_present_info(self, present_methods):
         if "bitmap" in present_methods:
@@ -272,17 +296,19 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 term.on_color_rgb(*rgb1) + term.color_rgb(*rgb2) + "▄"
                 for rgb1, rgb2 in zip(top_row, bot_row, strict=True)
             )
-            term_stream.write(term.move_xy(0, y // 2))
-            term_stream.write(line)
+            term_stream.write(term.move_xy(0, y // 2) + line)
+            # Show title and close button on the first line. Do here to avoid flicker.
+            if y == 0:
+                term_stream.write(
+                    term.normal
+                    + term.move_xy(0, 0)
+                    + self._clipped_title
+                    + term.move_xy(img.shape[1] - 1, 0)
+                    + "×"  # noqa: RUF001
+                )
 
-        # Reset and flush. Moving to (0, 0) prevents flicker by avoiding the jump to the *next* line.
-        term_stream.write(
-            term.move_xy(img.shape[1] - 1, 0)
-            + term.on_color_rgb(0, 0, 0)
-            + term.color_rgb(255, 255, 255)
-            + "×"
-        )
-        term_stream.write(term.move_xy(0, 0) + term.normal + "\n")
+        # Reset and flush. Moving to (0, 0) prevents jump-flicker by avoiding the jump to the *next* line.
+        term_stream.write(term.normal + term.move_xy(0, 0) + "\n")
         term_stream.flush()
 
     def _rc_set_logical_size(self, width, height):
@@ -295,7 +321,15 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         return self._closed
 
     def _rc_set_title(self, title):
-        pass
+        self._title = title
+        self._set_clipped_title()
+
+    def _set_clipped_title(self):
+        w = max(2, self._term_size[0] - 3)
+        if len(self._title) > w:
+            self._clipped_title = self._title[: w - 1] + "…"
+        else:
+            self._clipped_title = self._title
 
     def _rc_set_cursor(self, cursor):
         pass

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -87,6 +87,7 @@ class TerminalLoop(AsyncioLoop):
             term.fullscreen(),
             term.hidden_cursor(),
             term.cbreak(),
+            term.mouse_enabled(report_motion=True),
         ):
             super()._rc_run()
 
@@ -127,9 +128,49 @@ class TerminalRenderCanvas(BaseRenderCanvas):
             self._size_info.set_physical_size(pwidth, pheight, self._pixel_ratio)
             self.request_draw()
 
-        # Check for key pressed
+        # Check for key/mouse pressed
         keystroke = term.inkey(timeout=0)
-        if keystroke:
+        if not keystroke:
+            pass
+        elif keystroke.name and keystroke.name.startswith("MOUSE_"):
+            key_name = keystroke.name
+            # Get pos
+            x, y = keystroke.mouse_yx
+            x = float(x) * self._pixel_ratio
+            y = float(y) * 2 * self._pixel_ratio
+            # Get kind
+            if "MOTION" in key_name:
+                kind = "move"
+            elif "RELEASED" in key_name:
+                kind = "up"
+            else:
+                kind = "down"
+            # Get button and buttons. We ignore that buttons can be clicked when other buttons are down
+            button = 0
+            if "LEFT" in key_name:
+                button = 1
+            elif "RIGHT" in key_name:
+                button = 2
+            elif "MIDDLE" in key_name:
+                button = 3
+            buttons = () if kind == "up" else (button,)
+            # Modifiers
+            modifiers = []
+            if "SHIFT" in key_name:
+                modifiers.append("Shift")
+            # Submit!
+            ev = {
+                "event_type": f"pointer_{kind}",
+                "x": x,
+                "y": y,
+                "button": button,
+                "buttons": buttons,
+                "modifiers": tuple(modifiers),
+                "ntouches": 0,
+                "touches": {},
+            }
+            self.submit_event(ev)
+        else:
             # TODO: Exit? Since there is no close button, allow exit with ESCAPE in addition to CTRL-C?
             if keystroke.key_name == "KEY_ESCAPE":
                 loop.stop()
@@ -143,7 +184,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 ev = {
                     "event_type": "key_down",
                     "key": key,
-                    "modifiers": (),
+                    "modifiers": tuple(),
                 }
                 self.submit_event(ev)
 

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -20,7 +20,6 @@ Support for rendering in a terminal session, using the blessed library.
 __all__ = ["RenderCanvas", "TerminalRenderCanvas", "loop"]
 
 
-import os
 import io
 import sys
 from contextlib import contextmanager
@@ -110,7 +109,6 @@ KEY_MAP = {
 
 
 class TerminalLoop(AsyncioLoop):
-
     kitty_keyboard = None
 
     def _rc_run(self):
@@ -158,7 +156,8 @@ class TerminalRenderCanvas(BaseRenderCanvas):
 
     * Obviously the resolution is very low: each terminal represents just two pixels (vertically).
     * Limited support for modifiers in pointer and key events (only Shift).
-    * The experience may differ depending on the terminal you're at.
+    * The experience may differ depending on the terminal you're at. E.g. on terminals that don't
+      support the Kitty keyboard protocol the app does not receive key_up events.
 
     """
 
@@ -414,9 +413,9 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         if y == 0:
             overlay_builder.new_line(y)
             if self._expanded_menu:
-                overlay_builder.add_button("collapse_menu", "▲")  # ▲▼
+                overlay_builder.add_button("collapse_menu", "▴")  # ▲▴
             else:
-                overlay_builder.add_button("expand_menu", "▼")  # ▲▼
+                overlay_builder.add_button("expand_menu", "▾")  # ▼▾
             overlay_builder.add_button("close", "×")  # noqa: RUF001  - ×✕✖
             return overlay_builder.get_line(align_right=width)
         elif self._expanded_menu:
@@ -436,10 +435,6 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 overlay_builder.add_button("pixel_ratio_default", "default 1/8")
                 overlay_builder.add_button("pixel_ratio_minus", "-")
                 overlay_builder.add_button("pixel_ratio_plus", "+")
-                return overlay_builder.get_line(align_right=width)
-            elif y == 5:
-                overlay_builder.new_line(y)
-                overlay_builder.add_text(f"terminal: {os.environ.get('TERM_PROGRAM')}")
                 return overlay_builder.get_line(align_right=width)
 
     def _check_overlay_action(self, x, y):

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -17,6 +17,7 @@ Support for rendering in a terminal session, using the blessed library.
 __all__ = ["RenderCanvas", "TerminalRenderCanvas", "loop"]
 
 
+import os
 import io
 import sys
 from contextlib import contextmanager
@@ -109,9 +110,9 @@ KEY_MAP = {
 class TerminalLoop(AsyncioLoop):
     def _rc_run(self):
         with (
+            captured_stdout_and_stderr(),  # must come first
             term.fullscreen(),
             term.hidden_cursor(),
-            captured_stdout_and_stderr(),
             term.enable_kitty_keyboard(
                 report_events=True,
                 report_all_keys=True,
@@ -137,7 +138,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
 
     Arguments:
         pixel_ratio : float
-            The (initial) ratio that determines the logical size of the window. Default 0.25; the pixels are huge!
+            The (initial) ratio that determines the logical size of the window. Default 1/8; the pixels are huge!
 
     Restrictions of this backend:
 
@@ -149,7 +150,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
 
     _rc_canvas_group = TerminalCanvasGroup(loop)
 
-    def __init__(self, *args, pixel_ratio=0.25, **kwargs):
+    def __init__(self, *args, pixel_ratio=0.125, **kwargs):
         super().__init__(*args, **kwargs)
 
         # NOTE: it is assumed that there is exactly one canvas. If this assumption is violated I guess they will alternately flicker.
@@ -157,10 +158,13 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         self._pixel_ratio = pixel_ratio
 
         self._closed = False
+        self._title = ""
         self._term_size = 0, 0
         self._pointer_pos = (0, 0)
         self._pointer_buttons = ()
         self._pressed_keys = {}
+        self._overlay_builder = OverlayBuilder()  # reset on each draw
+        self._expanded_menu = False
 
         self._rc_gui_poll()
         self._final_canvas_init()
@@ -179,7 +183,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         the optimal pixel ratio for the terminal backend depends on the
         application.
 
-        Therefore, the pixel ratio can be changed using a button at the
+        Therefore, the pixel ratio can be changed via the dropdown menu at the
         top-right of the screen, or programmatically using this method.
         """
         self._pixel_ratio = float(pixel_ratio)
@@ -247,21 +251,10 @@ class TerminalRenderCanvas(BaseRenderCanvas):
                 modifiers = []
                 if "SHIFT" in stroke_name:
                     modifiers.append("Shift")
-                # Exit when the cross in the top-right is clicked
-                if (
-                    kind == "down"
-                    and button == 1
-                    and term_y == 0
-                    and term_x >= self._term_size[0] - 4
-                ):
-                    if term_x == self._term_size[0] - 4:
-                        p = round(np.log2(self._pixel_ratio))
-                        self.set_pixel_ratio(2 ** (p - 1))
-                    elif term_x == self._term_size[0] - 3:
-                        p = round(np.log2(self._pixel_ratio))
-                        self.set_pixel_ratio(2 ** (p + 1))
-                    elif term_x == self._term_size[0] - 1:
-                        loop.stop()
+                # Detect clicking on buttons
+                if kind == "down" and button == 1:
+                    if self._check_overlay_action(term_x, term_y):
+                        continue
                 # Submit!
                 ev = {
                     "event_type": f"pointer_{kind}",
@@ -347,21 +340,23 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         else:  # format == "rgba-u8":
             img = data
 
+        self._overlay_builder = overlay_builder = OverlayBuilder()
+
         # Push lines to stdout
         for y in range(0, img.shape[0], 2):
+            line_index = y // 2
             top_row = img[y][:, :3]
             bot_row = img[y + 1][:, :3]
             line = "".join(
                 term.on_color_rgb(*rgb1) + term.color_rgb(*rgb2) + "▄"
                 for rgb1, rgb2 in zip(top_row, bot_row, strict=True)
             )
-            term_stream.write(term.move_xy(0, y // 2) + line)
-            # Show close button on the first line. Do here rather then at end to avoid flicker.
-            if y == 0:
-                s = f"ratio {self._pixel_ratio:0.4g} -+ ×"  # noqa: RUF001
-                term_stream.write(
-                    term.normal + term.move_xy(img.shape[1] - len(s), 0) + s
-                )
+            term_stream.write(term.move_xy(0, line_index) + line)
+            # Apply overlay directly at each line (rather than at the end) to avoid flicker
+            res = self._get_overlay(overlay_builder, line_index, img.shape[1])
+            if res is not None:
+                offset, s = res
+                term_stream.write(term.normal + term.move_xy(offset, line_index) + s)
 
         # Reset and flush. Moving to (0, 0) prevents jump-flicker by avoiding the jump to the *next* line.
         term_stream.write(term.normal + term.move_xy(0, 0) + "\n")
@@ -377,10 +372,107 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         return self._closed
 
     def _rc_set_title(self, title):
+        self._title = title
         term_stream.write(term.set_window_title(title) + "\n")
+        term_stream.flush()
 
     def _rc_set_cursor(self, cursor):
         pass
+
+    def _get_overlay(self, overlay_builder, y, width):
+        if y == 0:
+            overlay_builder.new_line(y)
+            if self._expanded_menu:
+                overlay_builder.add_button("collapse_menu", "▲")  # ▲▼
+            else:
+                overlay_builder.add_button("expand_menu", "▼")  # ▲▼
+            overlay_builder.add_button("close", "×")  # noqa: RUF001  - ×✕✖
+            return overlay_builder.get_line(align_right=width)
+        elif self._expanded_menu:
+            if y == 2:
+                overlay_builder.new_line(y)
+                overlay_builder.add_text(f"title: {self._title}")
+                return overlay_builder.get_line(align_right=width)
+            elif y == 3:
+                overlay_builder.new_line(y)
+                overlay_builder.add_text(
+                    f"physical_size: {self._term_size[0]}x{self._term_size[1] * 2} pixels"
+                )
+                return overlay_builder.get_line(align_right=width)
+            elif y == 4:
+                overlay_builder.new_line(y)
+                overlay_builder.add_text(f"pixel_ratio: {self._pixel_ratio:0.4g}")
+                overlay_builder.add_button("pixel_ratio_default", "default 1/8")
+                overlay_builder.add_button("pixel_ratio_minus", "-")
+                overlay_builder.add_button("pixel_ratio_plus", "+")
+                return overlay_builder.get_line(align_right=width)
+            elif y == 5:
+                overlay_builder.new_line(y)
+                overlay_builder.add_text(f"terminal: {os.environ.get('TERM_PROGRAM')}")
+                return overlay_builder.get_line(align_right=width)
+
+    def _check_overlay_action(self, x, y):
+        action = self._overlay_builder.get_action(x, y)
+        if action is None:
+            return False
+
+        elif action == "close":
+            loop.stop()
+        elif action == "expand_menu":
+            self._expanded_menu = True
+        elif action == "collapse_menu":
+            self._expanded_menu = False
+        elif action == "pixel_ratio_minus":
+            p = round(np.log2(self._pixel_ratio))
+            self.set_pixel_ratio(2 ** (p - 1))
+        elif action == "pixel_ratio_plus":
+            p = round(np.log2(self._pixel_ratio))
+            self.set_pixel_ratio(2 ** (p + 1))
+        elif action == "pixel_ratio_default":
+            self.set_pixel_ratio(1 / 8)
+
+        return True
+
+
+class OverlayBuilder:
+    def __init__(self):
+        self.buttons_per_line = {}
+
+    def new_line(self, y):
+        self.buttons_per_line[y] = []
+        self.y = y
+        self.len = 0
+        self.parts = []
+
+    def add_button(self, action, label):
+        text = f" [ {label} ]"
+        x1 = self.len + 1
+        x2 = self.len + len(text) - 1
+        self.buttons_per_line[self.y].append((x1, x2, action))
+        self.parts.append(text)
+        self.len += len(text)
+
+    def add_text(self, text):
+        self.parts.append(text)
+        self.len += len(text)
+
+    def get_line(self, *, align_right=None):
+        text = "".join(self.parts)
+        le = self.len
+        if align_right:
+            self.buttons_per_line[self.y] = [
+                (align_right - le + x1, align_right - le + x2, a)
+                for x1, x2, a in self.buttons_per_line[self.y]
+            ]
+        self.parts = []
+        self.y = None
+        return align_right - le, text
+
+    def get_action(self, x, y):
+        buttons = self.buttons_per_line.get(y, [])
+        for x1, x2, action in buttons:
+            if x1 <= x <= x2:
+                return action
 
 
 # Make available under a common name

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -324,5 +324,13 @@ def test_wx_module():
     assert loop_class.name == "WxLoop"
 
 
+def test_terminal_module():
+    m = Module("terminal")
+
+    canvas_class = m.get_canvas_class()
+    m.check_canvas(canvas_class)
+    assert canvas_class.name == "TerminalRenderCanvas"
+
+
 if __name__ == "__main__":
     run_tests(globals())


### PR DESCRIPTION
Closes #207 

I'm presenting rendercanvas at Euroscipy in a few weeks, and a terminal backend would be a lovely surprise during a live demo.

<img width="800" height="784" alt="Screen Recording 2026-06-26 at 16 25 22" src="https://github.com/user-attachments/assets/be8cdb64-1455-4b0a-8660-32c4cbaff42a" />


AI disclaimer: I used Claude as lazy way to get the `blessed` calls I need. But I cleaned them up and made them more efficient in most cases.