### PR TITLE
Deal with cancelled draws from wgpu

### DIFF
--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -586,7 +586,13 @@ class BaseRenderCanvas:
             # Perform the user-defined drawing code. When this errors,
             # we should report the error and then continue, otherwise we crash.
             with log_exception("Draw error"):
-                self._draw_frame()
+                try:
+                    self._draw_frame()
+                except Exception as err:
+                    if type(err).__name__ == "DrawCancelled":
+                        scheduler.on_cancel_draw()
+                        return
+                    raise
 
             # Perform the presentation process. Might be async
             with log_exception("Present init error"):

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -590,7 +590,8 @@ class BaseRenderCanvas:
                     self._draw_frame()
                 except Exception as err:
                     if type(err).__name__ == "DrawCancelled":
-                        scheduler.on_cancel_draw()
+                        if scheduler is not None:
+                            scheduler.on_cancel_draw()
                         return
                     raise
 

--- a/rendercanvas/core/scheduler.py
+++ b/rendercanvas/core/scheduler.py
@@ -55,6 +55,7 @@ class Scheduler:
         self.set_update_mode(update_mode, min_fps=min_fps, max_fps=max_fps)
         self._draw_requested = True  # Start with a draw in ondemand mode
         self._ready_for_present = None
+        self._just_cancelled_a_frame = False
 
         # Keep track of fps
         self._draw_stats = 0, time.perf_counter()
@@ -114,7 +115,10 @@ class Scheduler:
 
         while True:
             # Determine delay
-            if not self._enabled:
+            if self._just_cancelled_a_frame:
+                self._just_cancelled_a_frame = False
+                delay = 0.1
+            elif not self._enabled:
                 delay = 0.1
             elif self._mode == "fastest" or self._max_fps <= 0:
                 delay = 0
@@ -208,6 +212,7 @@ class Scheduler:
 
     def on_cancel_draw(self):
         if self._ready_for_present is not None:
+            self._just_cancelled_a_frame = True  # wait longer for next frame
             self._ready_for_present.set()
             self._ready_for_present = None
 


### PR DESCRIPTION
wgpu-py will soon raise `wgpu.DrawCancelled`, see https://github.com/pygfx/wgpu-py/pull/820.

When this happens, the window is likely hidden/occluded (although in less likely event can be in another broken state). The best we can do is skip the frame.