### PR TITLE
Specify that bitmap does not have to match physical size

### DIFF
--- a/examples/snake.py
+++ b/examples/snake.py
@@ -33,7 +33,7 @@ def on_resize(event):
     # Incidentally, this results in precise physical pixels for the terminal backend :)
     global world
     w, h = int(event["width"]) // 8, int(event["height"]) // 8
-    world = np.zeros((h, w, 4), np.uint8)
+    world = np.zeros((h, w), np.uint8)
 
 
 @canvas.add_event_handler("key_down")

--- a/rendercanvas/contexts/bitmapcontext.py
+++ b/rendercanvas/contexts/bitmapcontext.py
@@ -40,7 +40,12 @@ class BitmapContext(BaseContext):
 
         Call this in the draw event. The bitmap must be an object that can be
         converted to a numpy array. It must represent a 2D image in either
-        grayscale or rgba format, with uint8 values
+        grayscale or rgba format, with uint8 values.
+
+        The bitmap does not have to match the physical size of the canvas;
+        backends will stretch the bitmap to match, though it's not specified
+        what interpolation method is used.
+
         """
 
         arr = np.asarray(bitmap)


### PR DESCRIPTION
Closes #125.

Interpolation with nearest-neighbour is easy enough to implement (see terminal backend), and allowing arbitrarily sized images allows for interesting use-cases, like snake that is exactly 1px wide, using logical size to make the math easier, etc.