### PR TITLE
All backends use nearest interpolation when bitmap is smaller than physical size

### DIFF
--- a/rendercanvas/contexts/_fullscreen.py
+++ b/rendercanvas/contexts/_fullscreen.py
@@ -94,7 +94,9 @@ class FullscreenTexture:
             sample_count=1,
         )
         self._texture_view = self._texture.create_view()
-        self._sampler = device.create_sampler()
+        # Use nearest neighbor interpolation when the bitmap is smaller than
+        # the physical size, and linear when it is larger.
+        self._sampler = device.create_sampler(min_filter="linear", mag_filter="nearest")
 
     def _update_texture(self, texture_data):
         device = self._device

--- a/rendercanvas/contexts/bitmapcontext.py
+++ b/rendercanvas/contexts/bitmapcontext.py
@@ -43,9 +43,11 @@ class BitmapContext(BaseContext):
         grayscale or rgba format, with uint8 values.
 
         The bitmap does not have to match the physical size of the canvas;
-        backends will stretch the bitmap to match, though it's not specified
-        what interpolation method is used.
-
+        backends will stretch the bitmap to match the window. The interpolation
+        method is currently not specified, but all builtin backends use
+        nearest-neighbor interpolation (when the bitmap is smaller than the
+        physical size), so that applications can provide N times smaller bitmaps
+        to produce a pixelated visualization.
         """
 
         arr = np.asarray(bitmap)

--- a/rendercanvas/core/renderview-afm.js
+++ b/rendercanvas/core/renderview-afm.js
@@ -213,6 +213,7 @@ class AnywidgetRenderView extends BaseRenderView {
     const viewElement = document.createElement('img')
     viewElement.decoding = 'sync'
     viewElement.loading = 'eager'
+    viewElement.style.imageRendering = 'pixelated' // if image size does not match, use nearest-neighbor
     viewElement.style.touchAction = 'none' // prevent default pan/zoom behavior
     viewElement.ondragstart = () => false // prevent browser's built-in image drag
 

--- a/rendercanvas/core/renderview-client.js
+++ b/rendercanvas/core/renderview-client.js
@@ -28,6 +28,7 @@ class ClientRenderView extends BaseRenderView {
     const viewElement = document.createElement('img')
     viewElement.decoding = 'sync'
     viewElement.loading = 'eager'
+    viewElement.style.imageRendering = 'pixelated' // if image size does not match, use nearest-neighbor
     viewElement.style.touchAction = 'none' // prevent default pan/zoom behavior
     viewElement.ondragstart = () => false // prevent browser's built-in image drag
 

--- a/rendercanvas/pyodide.py
+++ b/rendercanvas/pyodide.py
@@ -194,8 +194,7 @@ class PyodideRenderCanvas(BaseRenderCanvas):
             # This effectively uploads the image to a GPU texture (represented by the offscreen canvas).
             self._offscreen_canvas.getContext("2d").putImageData(image_data, 0, 0)
             # Then we draw the offscreen texture into the real texture, scaling is applied.
-            # Do we want a smooth image or nearest-neighbour? Depends on the situation.
-            # We should decide what we want backends to do, and maybe have a way for users to chose.
+            # Use nearest neighbor interpolation, since it allows for pixelated graphics.
             ctx = self._canvas_element.getContext("2d")
             ctx.imageSmoothingEnabled = False
             ctx.drawImage(self._offscreen_canvas, 0, 0, cw, ch)

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -345,7 +345,7 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
             rect1 = QtCore.QRect(0, 0, image.width(), image.height())
             rect2 = self.rect()
 
-            # Paint the image. Nearest neighbor interpolation, like the other backends.
+            # Paint the image using nearest neighbor interpolation.
             painter = QtGui.QPainter(self)
             painter.setRenderHints(painter.RenderHint.Antialiasing, False)
             painter.setRenderHints(painter.RenderHint.SmoothPixmapTransform, False)

--- a/rendercanvas/terminal.py
+++ b/rendercanvas/terminal.py
@@ -351,7 +351,7 @@ class TerminalRenderCanvas(BaseRenderCanvas):
         term_w, term_h = self._term_size[0], self._term_size[1] * 2
         data_h, data_w = data.shape[:2]
 
-        # Resize image if necessary
+        # Resize image if necessary, using nearest neighbor interpolation.
         if term_w == data_w or term_h == data_h:
             img = data
         else:

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -247,7 +247,11 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         if not self._draw_lock:
             self._time_to_paint()
         if self._last_image is not None:
-            dc.DrawBitmap(self._last_image, 0, 0, False)
+            # Paint the image using nearest neighbor interpolation.
+            gc = wx.GraphicsContext.Create(dc)
+            gc.SetInterpolationQuality(wx.INTERPOLATION_NONE)
+            lw, lh = self._size_info["logical_size"]
+            gc.DrawBitmap(self._last_image, 0, 0, lw, lh)
         else:
             event.Skip()
         del dc
@@ -341,7 +345,6 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
         assert format == "rgba-u8"
         width, height = data.shape[1], data.shape[0]
         self._last_image = wx.Bitmap.FromBufferRGBA(width, height, data)
-        self._last_image.SetScaleFactor(self.get_pixel_ratio())
 
     def _rc_set_logical_size(self, width, height):
         width, height = int(width), int(height)


### PR DESCRIPTION
Is now also mentioned in the docs. Not fully official spec, but "recommended for backends".

Backends that already did:
  * glfw (via bitmap-wgu adapter)
  * qt
  * pyodide
  * terminal
  
Updated backends:
* wx
* http
* anywidget

----

Some more context.

This does not affect the wgpu context; there the context provides the texture to write to, which precisely matches the canvas' physical size.

The main reason is that when creating simple low-res bitmaps, like the snake example, the canvas shows these big pixels, rather than a smoothed version of it. 
