### PR TITLE
Support presenting to a native Wayland surface on Qt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
 
   # Test for specific backends. Ran separately, since GUI frameworks don't like to be loaded in the same process.
   test-backends:
-    name: 'Test backend ${{ matrix.backendname }}'
+    name: 'Test backend ${{ matrix.backendname }} on ${{ matrix.os }}'
     runs-on:  ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -170,6 +170,10 @@ jobs:
             deps: 'PySide6'
             testname: 'qt'
             os: windows-latest
+          - backendname: 'pyside6'
+            deps: 'PySide6'
+            testname: 'qt'
+            os: macos-latest
           - backendname: 'pyqt6'
             deps: 'PyQt6'
             testname: 'qt'
@@ -210,6 +214,86 @@ jobs:
     - name: Test backend canvas
       run: |
         pytest -v tests/test_backend_${{ matrix.testname || matrix.backendname }}.py
+
+  # Test the qt backend on Linux, on Wayland and on X11. On Wayland, Qt presents to
+  # a native Wayland surface, but only if the Qt lib can provide its wl_display.
+  # Qt libs that cannot are put on XWayland, which is a different code path.
+  test-qt-linux:
+    name: 'Test qt on Linux (${{ matrix.case }})'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # A Wayland session, with a Qt that can provide its wl_display.
+          - case: 'wayland'
+            pyversion: '3.14'
+            qtdep: 'PySide6'
+            expect: 'wayland'
+          # A Wayland session, with a Qt that cannot (< 6.10): must use XWayland.
+          - case: 'wayland-old-qt'
+            pyversion: '3.12'
+            qtdep: 'PySide6==6.9.*'
+            expect: 'xcb'
+          # A system that only has x11.
+          - case: 'x11'
+            pyversion: '3.14'
+            qtdep: 'PySide6'
+            expect: 'xcb'
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.pyversion }}
+    - name: Install display servers and Vulkan drivers
+      run: |
+        sudo apt update -y -qq
+        sudo apt install --no-install-recommends -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+        sudo apt install --no-install-recommends -y weston xwayland xvfb
+        # Qt's xcb platform plugin needs these (the native wayland plugin does not).
+        sudo apt install --no-install-recommends -y libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1 libxkbcommon-x11-0
+    - name: Install package and dev dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[tests]
+        pip install '${{ matrix.qtdep }}'
+        rm -r rendercanvas
+    - name: Test backend canvas
+      run: |
+        export XDG_RUNTIME_DIR=/tmp/xdg-runtime-dir
+        mkdir -p $XDG_RUNTIME_DIR && chmod 700 $XDG_RUNTIME_DIR
+        if [ "${{ matrix.case }}" = "x11" ]; then
+          # An X11-only system.
+          export XDG_SESSION_TYPE=x11
+          Xvfb :99 -screen 0 800x600x24 &
+          for i in $(seq 1 40); do [ -S /tmp/.X11-unix/X99 ] && break; sleep 0.5; done
+          export DISPLAY=:99
+        else
+          # A Wayland session. Enable XWayland too, so the wayland-old-qt case
+          # (whose Qt cannot present to a native Wayland surface) can fall back to it.
+          # The X11 socket dir normally already exists (mode 1777); ensure it does.
+          mkdir -p /tmp/.X11-unix
+          weston --backend=headless-backend.so --socket=wayland-ci --no-config --xwayland &
+          for i in $(seq 1 40); do [ -S $XDG_RUNTIME_DIR/wayland-ci ] && break; sleep 0.5; done
+          export WAYLAND_DISPLAY=wayland-ci
+          export XDG_SESSION_TYPE=wayland
+          if [ "${{ matrix.expect }}" = "xcb" ]; then
+            # Wait for XWayland's X server and adopt its display.
+            for i in $(seq 1 40); do sock=$(ls /tmp/.X11-unix/X* 2>/dev/null | head -1); [ -n "$sock" ] && break; sleep 0.5; done
+            export DISPLAY=":${sock##*X}"
+          fi
+        fi
+        # Check that Qt uses the expected platform, otherwise this job tests nothing.
+        python -c "
+        from PySide6 import QtWidgets
+        import rendercanvas.qt
+        app = QtWidgets.QApplication([])
+        expect = '${{ matrix.expect }}'
+        assert app.platformName() == expect, f'expected {expect}, got {app.platformName()}'
+        print('Qt runs on', expect)
+        "
+        pytest -v tests/test_backend_qt.py
 
   # Test that the examples run without error, and screenshots match
   test-examples:

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -197,6 +197,13 @@ Alternatively, you can select the specific qt library to use, making it easy to 
     loop.run()  # calls app.exec_()
 
 
+For Linux users with Wayland: Qt can run on Wayland natively. For
+``present_method="screen"`` rendercanvas needs the ``wl_display`` that Qt is connected to,
+because a Wayland surface can only be used with the display-connection that created it.
+Qt libs that cannot provide it (which depends on the Qt library and version) are put on
+XWayland instead, by setting the env var ``QT_QPA_PLATFORM`` to 'xcb'. To force either
+mode, set ``QT_QPA_PLATFORM`` to 'xcb' or 'wayland' yourself.
+
 It is technically possible to e.g. use a ``glfw`` canvas with the Qt loop. However, this is not recommended because Qt gets confused in the presence of other windows and may hang or segfault.
 But the other way around, running a Qt canvas in e.g. the trio loop, works fine:
 

--- a/rendercanvas/contexts/wgpucontext.py
+++ b/rendercanvas/contexts/wgpucontext.py
@@ -159,18 +159,31 @@ class WgpuContextToScreen(WgpuContext):
         self._wgpu_context.configure(**config)
 
     def _unconfigure(self) -> None:
-        self._wgpu_context.unconfigure()
+        if self._wgpu_context is not None:
+            self._wgpu_context.unconfigure()
 
     def _get_current_texture(self) -> object:
         return self._wgpu_context.get_current_texture()
 
     def _rc_present(self, *, force_sync: bool = False) -> dict:
+        if self._wgpu_context is None:
+            return {"method": "skip"}  # the canvas is closed
         self._wgpu_context.present()
         return {"method": "screen"}
 
     def _rc_close(self):
         if self._wgpu_context is not None:
-            self._wgpu_context.unconfigure()
+            wgpu_context, self._wgpu_context = self._wgpu_context, None
+            wgpu_context.unconfigure()
+            # Release the surface now, instead of leaving it to the garbage
+            # collector. The surface only makes sense as long as the window
+            # exists, and on Wayland it is owned by the display-connection of
+            # the toolkit, so releasing it after the toolkit has torn that
+            # connection down is a use-after-free. Dropping our reference (above)
+            # already does this, but only if no other references are left.
+            release = getattr(wgpu_context, "_release", None)  # private method
+            if release is not None:
+                release()
 
 
 class WgpuContextToBitmap(WgpuContext):

--- a/rendercanvas/core/coreutils.py
+++ b/rendercanvas/core/coreutils.py
@@ -362,8 +362,11 @@ if sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND:
 
     # ----- Tweak Qt
 
-    # Force Qt to use X11. Qt is more flexible - it ok if e.g. PySide6 is already imported.
-    os.environ["QT_QPA_PLATFORM"] = "xcb"
+    # Qt is not forced to X11: it runs on Wayland natively. The default
+    # present-method ('bitmap') needs no native handles, and for 'screen'
+    # present we ask Qt for the wl_display that it is itself connected to
+    # (see qt.py), which is the only display that its surface is valid on.
+
     # Force wx to use X11, probably.
     os.environ["GDK_BACKEND"] = "x11"
 

--- a/rendercanvas/qt.py
+++ b/rendercanvas/qt.py
@@ -5,6 +5,7 @@ can be used as a standalone window or in a larger GUI.
 
 __all__ = ["QRenderCanvas", "QRenderWidget", "QtLoop", "RenderCanvas", "loop"]
 
+import os
 import sys
 import ctypes
 import importlib
@@ -14,8 +15,8 @@ from .base import WrapperRenderCanvas, BaseCanvasGroup, BaseRenderCanvas, BaseLo
 from .core.coreutils import (
     logger,
     get_alt_x11_display,
-    get_alt_wayland_display,
     select_qt_lib,
+    SYSTEM_IS_WAYLAND,
 )
 
 
@@ -158,6 +159,86 @@ BITMAP_FORMAT_MAP = {
     "i-u8": QtGui.QImage.Format.Format_Grayscale8,
     "i-u16": QtGui.QImage.Format.Format_Grayscale16,
 }
+
+
+def qt_lib_can_get_wayland_display():
+    """Get whether this Qt lib can report which wl_display it is connected to."""
+    # Qt6 exposes the native handles via QNativeInterface.
+    native_interface = getattr(QtGui, "QNativeInterface", None)
+    if hasattr(native_interface, "QWaylandApplication"):
+        return True
+    # Qt5 exposes the native handles via the (semi-private) platform native interface.
+    if hasattr(QtGui.QGuiApplication, "platformNativeInterface"):
+        return True
+    return False
+
+
+def get_qt_platform_name():
+    """Get the name of the qpa platform plugin that Qt is running on.
+
+    This is e.g. 'wayland', 'xcb', 'windows' or 'cocoa'. Returns an empty
+    string if there is no application object (yet).
+    """
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        return ""
+    return app.platformName().lower()
+
+
+def get_qt_wayland_display():
+    """Get (the pointer to) the wl_display that Qt is connected to.
+
+    Returns None if it cannot be obtained. Note that a wl_surface can only be
+    used with the display that created it, so a fresh wl_display_connect() is
+    not a valid substitute (see coreutils.py).
+    """
+    app = QtWidgets.QApplication.instance()
+    if app is None or get_qt_platform_name() != "wayland":
+        return None
+
+    # Qt6 exposes the handles via QNativeInterface. In PySide6, nativeInterface()
+    # resolves to the interface matching the current platform (QWaylandApplication).
+    try:
+        display = app.nativeInterface().display()
+        if display:
+            return int(display)
+    except (AttributeError, TypeError):
+        pass
+
+    # Qt5 exposes the handles via the (semi-private) platform native interface.
+    try:
+        pni = app.platformNativeInterface()
+        display = pni.nativeResourceForIntegration("wl_display")
+        if display:
+            return int(display)
+    except (AttributeError, TypeError):
+        pass
+
+    return None
+
+
+def fall_back_to_xwayland_if_needed():
+    """Put Qt on XWayland if it cannot present to a native Wayland surface.
+
+    A Wayland surface can only be used with the display-connection that created
+    it, so if this Qt lib cannot tell us its wl_display, we cannot present to
+    screen (see ``_get_surface_ids``). We then use XWayland, so that the x11
+    code path can be used instead. Note that Qt selects the platform when the
+    application is instantiated, so this must happen before that.
+    """
+    if not (sys.platform.startswith("linux") and SYSTEM_IS_WAYLAND):
+        return
+    if already_had_app_on_import:
+        return  # too late, Qt has already selected a platform
+    if os.environ.get("QT_QPA_PLATFORM"):
+        return  # the user made an explicit choice
+    if not qt_lib_can_get_wayland_display():
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
+
+
+# Qt selects its platform when the application is instantiated, so we must make
+# this decision at import-time.
+fall_back_to_xwayland_if_needed()
 
 
 def enable_hidpi():
@@ -304,12 +385,24 @@ class QRenderWidget(BaseRenderCanvas, QtWidgets.QWidget):
                 "window": int(self.winId()),
             }
         elif sys.platform.startswith("linux"):
-            if False:
-                # We fall back to XWayland, see coreutils.py
+            # Note that the platform to target is decided by Qt (the qpa
+            # plugin), not by the session: under a Wayland session Qt may well
+            # be running on XWayland, in which case winId() is an X11 window.
+            if get_qt_platform_name() == "wayland":
+                wayland_display = get_qt_wayland_display()
+                if wayland_display is None:
+                    # Without the display that Qt itself is connected to, the
+                    # wl_surface from winId() is unusable. Let the caller fall
+                    # back to bitmap present rather than crash.
+                    logger.warning(
+                        "Cannot get the Wayland display from Qt, "
+                        "so cannot present to screen."
+                    )
+                    return None
                 return {
                     "platform": "wayland",
                     "window": int(self.winId()),
-                    "display": int(get_alt_wayland_display()),
+                    "display": wayland_display,
                 }
             else:
                 return {

--- a/tests/test_backend_qt.py
+++ b/tests/test_backend_qt.py
@@ -10,9 +10,13 @@ frameworks in the same process never works.
 import sys
 import importlib
 
+import gc
+import time
+import weakref
+
 import pytest
-from testutils import run_tests
-from testutils_backends import BACKEND_TEST_FUNCS, NativeHelper
+from testutils import run_tests, can_use_wgpu_lib
+from testutils_backends import BACKEND_TEST_FUNCS, NativeHelper, _get_draw_function
 
 
 # Only run when running directly (through Python or pytest)
@@ -40,6 +44,7 @@ if QtWidgets is None:
 
 
 from rendercanvas.base import BaseRenderCanvas, WrapperRenderCanvas
+from rendercanvas.contexts.wgpucontext import WgpuContextToScreen
 from rendercanvas.qt import RenderCanvas, RenderWidget, loop
 from rendercanvas.qt import QRenderWidget, QRenderCanvas
 
@@ -64,6 +69,40 @@ class QtHelper(NativeHelper):
 @pytest.mark.parametrize("func", BACKEND_TEST_FUNCS)
 def test_backend_qt(func):
     func(RenderCanvas, loop, QtHelper())
+
+
+def test_backend_qt_present_to_screen():
+    # Render with present_method 'screen'. Unlike the default ('bitmap'), this
+    # exercises the code to obtain a native surface, and on Wayland the code to
+    # get the wl_display that Qt is connected to. See rendercanvas.qt.
+    if not can_use_wgpu_lib:
+        pytest.skip("Skipping tests that needs the wgpu lib")
+
+    import wgpu
+
+    canvas = RenderCanvas(size=(640, 480), present_method="screen")
+
+    # Confirm that we really present to screen. Otherwise this would silently
+    # test the same thing as the bitmap present (i.e. not the screen code path).
+    context = canvas.get_context("wgpu")
+    assert isinstance(context, WgpuContextToScreen)
+
+    device = wgpu.gpu.request_adapter_sync().request_device_sync()
+    canvas.request_draw(_get_draw_function(device, canvas))
+
+    loop.call_later(0.5, canvas.close)
+    loop.run()
+
+    assert canvas.get_closed()
+
+    canvas_ref = weakref.ref(canvas)
+    del canvas
+    gc.collect()
+    time.sleep(0.02)
+    gc.collect()
+
+    assert canvas_ref() is None
+    assert loop._BaseLoop__state == "off"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
xref: https://github.com/pygfx/rendercanvas/issues/36

got to test this on an actual linux machine soon running wayland. Curious to see this in action, but the commits look good.

- CI Tested on qt+x11
- CI Tested on qt+xwayland
- CI Tested on qt+wayland

<details><summary>Claude's notes</summary>

### What this does

On Wayland, rendercanvas puts Qt on XWayland, and the code to present to a native Wayland surface is disabled with an `if False`. That code could not have worked: it pairs the `wl_surface` from `winId()` with a display from `get_alt_wayland_display()`, i.e. a fresh `wl_display_connect()`. A `wl_surface` is a proxy owned by the connection that created it, so libwayland aborts with `Proxy and queue point to different wl_displays` as soon as a buffer is attached. The existing comment ("this segfaults, so it looks like the real display object is needed?") diagnosed this correctly.

Worth noting for anyone testing this: creating the surface succeeds with the wrong display, and so does `wgpuSurfaceGetCapabilities`. It only aborts once frames are actually presented, so a probe has to render.

Qt can say what display it is connected to, and that display is the only one its surface is valid on. So this:

- gets the real `wl_display` from Qt (`QNativeInterface::QWaylandApplication` on Qt6, the platform native interface on Qt5);
- decides the platform from the qpa plugin Qt actually uses rather than from `sys.platform`, since under a Wayland session Qt may still be on XWayland, where `winId()` is an X11 window;
- only puts Qt on XWayland when the Qt lib cannot provide its display, so those libs keep using the x11 code-path. Qt picks its platform when the application is instantiated, so this is decided at import-time.

### A second bug this uncovered

`WgpuContextToScreen._rc_close` unconfigured the wgpu context but never released the surface, leaving it to the garbage collector. On Wayland the surface belongs to the toolkit's display-connection, so during interpreter shutdown `wgpuSurfaceRelease` ran after Qt had torn that connection down — a use-after-free (gdb showed the freed map was Qt's `wl_display` + 0x90). x11 never hit this because an X11 window id is just a number that outlives any connection. This was unreachable before, so it is newly-exposed rather than a regression.

### Which Qt versions get native Wayland

`QNativeInterface.QWaylandApplication` turns out to be recent. Checked each PySide6 minor:

| PySide6 | `QNativeInterface` | `QWaylandApplication` | result |
| --- | --- | --- | --- |
| 6.11, 6.10 | yes | yes | native Wayland |
| 6.9, 6.8, 6.7 | yes | no | XWayland |
| 6.6, 6.5 | no | no | XWayland |

So most installs today keep the current behaviour, and this is a no-op for them. It also means the check has to be for `QWaylandApplication` specifically: `QNativeInterface` alone exists since 6.7 and would be a false positive on 6.7–6.9.

### Behaviour changes worth a look

- An explicit `QT_QPA_PLATFORM` is no longer overridden. Previously `QT_QPA_PLATFORM=xcb` was set unconditionally under Wayland, so a user asking for `wayland` was silently overruled. Forcing still works in both directions.
- The `_get_surface_ids` → `None` → bitmap path is now only reachable when a `QApplication` already exists at import (`already_had_app_on_import`) with a Qt lib that cannot provide its display. It is too late to force xcb there, so degrading to bitmap beats crashing.
- `wgpucontext.py` is shared with glfw. Releasing the surface at close rather than at GC is correct for every backend, but it is not Qt-only code. Happy to split it out.

### Testing

Tested against a headless weston with lavapipe (software Vulkan), on PySide6 only, since that is all that was installed locally. Presenting to screen works for both a top-level canvas and an embedded `QRenderWidget`, and the teardown crash is gone. `tests/test_backend_qt.py` passes on native Wayland and on xcb. The rest of the suite is unchanged (the 3 `test_meta` failures locally are a pre-existing git-version mismatch, identical on a stashed baseline).

The second commit adds a `test-qt-linux` job covering the three cases: Wayland with a capable Qt, Wayland with PySide6 6.9 (must fall back to XWayland), and x11-only. Each case asserts which qpa platform Qt ends up on before running the tests, because a case that silently fell back would otherwise still pass and test nothing. I checked the assertion actually fails the step when the platform is wrong.

The jobs were validated by running the same steps in ubuntu/python docker images, which turned up two things worth knowing: the pip PySide6 wheel does ship `libqwayland.so`, and Qt's xcb plugin needs `libxcb-cursor0` (Qt >= 6.5), which the existing dependency list does not install.

### Not addressed

glfw and wx are untouched and stay on XWayland, so they are not equivalent to Qt after this. Neither exposes the display of its connection (glfw could via `glfw.get_wayland_display()`, wx has no way at all). glfw on Wayland was not testable here: `glfw.init()` hangs under headless weston because libdecor cannot initialise GTK, before rendercanvas is involved.

</details>
