### PR TITLE
Two fixes for VSCode

### DIFF
--- a/rendercanvas/_version.py
+++ b/rendercanvas/_version.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 # This is the base version number, to be bumped before each release.
 # The build system detects this definition when building a distribution.
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 
 # Set this to your library name
 project_name = "rendercanvas"

--- a/rendercanvas/anywidget.py
+++ b/rendercanvas/anywidget.py
@@ -127,7 +127,8 @@ class AnywidgetRenderCanvas(BaseRenderCanvas, anywidget.AnyWidget):
             ),
             display_id=True,
         )
-        self.request_draw()
+
+        self._rfb_schedule_maybe_draw()
 
     def _replace_snapshot(self, array):
         pending_display = self._rfb_pending_snapshot_display
@@ -187,8 +188,9 @@ class AnywidgetRenderCanvas(BaseRenderCanvas, anywidget.AnyWidget):
         should_draw = (
             self._rfb_draw_requested
             and frames_in_flight < self._max_buffered_frames
-            and (self._has_visible_views or self._rfb_pending_snapshot_display)
-        )
+            and self._has_visible_views
+        ) or self._rfb_pending_snapshot_display is not None
+
         # Do the draw if we should.
         if should_draw:
             self._rfb_draw_requested = False

--- a/rendercanvas/core/renderview.js
+++ b/rendercanvas/core/renderview.js
@@ -595,8 +595,10 @@ class BaseRenderView {
 
     viewElement.addEventListener('pointerdown', (ev) => {
       // When pointer is down, set focus to the focus-element.
+      // Focus after a short delay, otherwise VSCode takes focus away immediately.
       if (!LOOKS_LIKE_MOBILE) {
-        this._focusElement.focus({ preventScroll: true, focusVisible: false })
+        const fe = this._focusElement
+        window.setTimeout(function () { fe.focus({ preventScroll: true, focusVisible: false }) }, 50)
       }
       // capture the pointing device.
       // Because we capture the event, there will be no other events when buttons are pressed down,


### PR DESCRIPTION
* [x] Fix that key events did not work, because vscode took away the focus.
* [x] Fix snapshots. Closes #218 
* [x] Minor version bump 