### PR TITLE
Fix vscode key events for real

### DIFF
--- a/rendercanvas/_version.py
+++ b/rendercanvas/_version.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 # This is the base version number, to be bumped before each release.
 # The build system detects this definition when building a distribution.
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 # Set this to your library name
 project_name = "rendercanvas"

--- a/rendercanvas/core/renderview.js
+++ b/rendercanvas/core/renderview.js
@@ -597,8 +597,9 @@ class BaseRenderView {
       // When pointer is down, set focus to the focus-element.
       // Focus after a short delay, otherwise VSCode takes focus away immediately.
       if (!LOOKS_LIKE_MOBILE) {
-        const fe = this._focusElement
-        window.setTimeout(function () { fe.focus({ preventScroll: true, focusVisible: false }) }, 50)
+        const focusFunc = () => this._focusElement.focus({ preventScroll: true, focusVisible: false })
+        window.setTimeout(focusFunc, 25)
+        window.setTimeout(focusFunc, 250)
       }
       // capture the pointing device.
       // Because we capture the event, there will be no other events when buttons are pressed down,
@@ -875,11 +876,12 @@ class BaseRenderView {
       if (this.sizeElement.offsetParent === null) {
         return
       }
+      // Prevent envs like VSCode from capturing and using e.g. up/down
+      ev.stopPropagation()
       // Ignore repeated events (key being held down)
       if (ev.repeat) {
         return
       }
-      // No need for stopPropagation or preventDefault because we are in a text-input.
 
       const modifiers = getModifiers(ev)
 
@@ -898,6 +900,7 @@ class BaseRenderView {
       if (this.sizeElement.offsetParent === null) {
         return
       }
+      ev.stopPropagation()
 
       const modifiers = getModifiers(ev)
 


### PR DESCRIPTION
In #235 I first had a timeout of 100ms and I changed that to 50ms in the last moment, but then it apparently does not work anymore; we need to be a bit more persistent.