### PR TITLE
Fix two scheduling bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,13 @@ from rendercanvas.auto import RenderCanvas, loop
 canvas = RenderCanvas(update_mode="continuous")
 context = canvas.get_bitmap_context()
 
+
 @canvas.request_draw
 def animate():
     w, h = canvas.get_logical_size()
     bitmap = np.random.uniform(0, 255, (h, w)).astype(np.uint8)
     context.set_bitmap(bitmap)
+
 
 loop.run()
 ```
@@ -106,8 +108,8 @@ Embed in a Qt application:
 from PySide6 import QtWidgets
 from rendercanvas.qt import QRenderWidget
 
-class Main(QtWidgets.QWidget):
 
+class Main(QtWidgets.QWidget):
     def __init__(self):
         super().__init__()
 

--- a/rendercanvas/core/scheduler.py
+++ b/rendercanvas/core/scheduler.py
@@ -51,11 +51,11 @@ class Scheduler:
         # ... = canvas.get_context() -> No, context creation should be lazy!
 
         # Scheduling variables
-        self.set_enabled(True)
-        self.set_update_mode(update_mode, min_fps=min_fps, max_fps=max_fps)
+        self._enabled = True
         self._draw_requested = True  # Start with a draw in ondemand mode
         self._ready_for_present = None
         self._just_cancelled_a_frame = False
+        self.set_update_mode(update_mode, min_fps=min_fps, max_fps=max_fps)
 
         # Keep track of fps
         self._draw_stats = 0, time.perf_counter()
@@ -95,8 +95,8 @@ class Scheduler:
             self._max_fps = max(1, float(max_fps))
 
     def set_enabled(self, enabled: bool):
-        self._enabled = bool(enabled)
-        if self._enabled:
+        if not self._enabled:
+            self._enabled = bool(enabled)
             self._draw_requested = True
 
     def request_draw(self):
@@ -195,6 +195,7 @@ class Scheduler:
                 # terms of user-experience, the cost of this delay is probably
                 # larger than the benefit of the potential fps increase.
 
+                last_draw_time = time.perf_counter()
                 self._ready_for_present = Event()
                 canvas._rc_request_draw()
                 del canvas


### PR DESCRIPTION
Found during #227, contributing in separate pr.

Fixes:
* In ondemand mode, with a nonzero fps, it drew *much* faster, because `last_draw_time` was never set.
* Setting the canvas to enabled should only request a new draw if it was previously disabled.

For reference, the scheduling code that uses `last_draw_time`:

```py
    elif self._mode == "ondemand":
                # ondemand: draw when needed (detected by calls to request_draw).
                # Aim for max_fps when drawing is needed, otherwise min_fps.
                if self._draw_requested:
                    do_draw = True
                elif (
                    self._min_fps > 0
                    and time.perf_counter() - last_draw_time > 1 / self._min_fps
                ):
                    do_draw = True
```

