### PR TITLE
Add comment for post-close polling

### DIFF
--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -770,7 +770,18 @@ class BaseRenderCanvas:
     # %% Methods for the subclass to implement
 
     def _rc_gui_poll(self):
-        """Process native events."""
+        """Process native events.
+
+        This method is called by the base class before each draw to move
+        events into the rendercanvas event system.
+
+        In some cases one can naturally assume that the 'native' backend is running
+        and events are already processed. E.g. when in a notebook-like env.
+
+        In cases where the backend comes with its own event loop that already processes
+        events, ``_rc_gui_poll``  only need to do a poll if the current loop is
+        *not* the backend's own loop. E.g. qt and wx.
+        """
         pass
 
     def _rc_get_present_info(self, present_methods: list[str]) -> dict | None:
@@ -871,7 +882,10 @@ class BaseRenderCanvas:
 
         In a backend, all flows that lead to a close must call ``.close()``, so
         that ``BaseRenderCanvas`` has a clear place to handle closing. It calls
-        ``_rc_close()``  from there. The base class will call this method exactly once.
+        ``_rc_close()`` from there. The base class will call this method exactly once.
+
+        Note that if this is the last canvas to close, the loop is stopped immediately,
+        and some backends need some explicit polling in this case. Also see wx and glfw backends.
 
         Note that backends may also have a ``close()`` method, which is
         overridden by the base class.

--- a/rendercanvas/base.py
+++ b/rendercanvas/base.py
@@ -683,16 +683,16 @@ class BaseRenderCanvas:
             return
         self.__is_closed = True
         errors = []
-        # Close the native canvas
-        try:
-            self._rc_close()
-        except Exception as err:
-            errors.append(err)
         # Unregister
         loop = None
         if self._rc_canvas_group is not None:
             loop = self._rc_canvas_group.get_loop()
             self._rc_canvas_group._unregister_canvas(self)
+        # Close the native canvas
+        try:
+            self._rc_close()
+        except Exception as err:
+            errors.append(err)
         # Clear the draw-function, to avoid it holding onto e.g. wgpu objects.
         self._draw_frame = None  # type: ignore
         # Clear the canvas context too.

--- a/rendercanvas/wx.py
+++ b/rendercanvas/wx.py
@@ -382,6 +382,7 @@ class WxRenderWidget(BaseRenderCanvas, wx.Window):
             parent.Destroy()
         else:
             self.Destroy()
+        # wx needs some loop iters to close a canvas, so if this is the last canvas, poll it for a short while.
         if not self._rc_canvas_group.get_canvases():
             end_time = time.perf_counter() + 0.1
             while time.perf_counter() < end_time:


### PR DESCRIPTION
glfw and wx need a bit of polling after the last window closes, otherwise the window stays on screen. The way this worked felt a bit hacky, and I initially planned for the base class to handle that polling. However, that seems to make thinks unnecessarily complex, so I just left it as is, and added a comment and docs.

Also fixes the triggering of this extra polling, which was broken by #227.
