### PR TITLE
Fix: Detect the asyncadapter via a thread-local

### DIFF
--- a/rendercanvas/core/coreutils.py
+++ b/rendercanvas/core/coreutils.py
@@ -14,6 +14,8 @@ import ctypes.util
 from contextlib import contextmanager
 from collections import namedtuple
 
+from ..utils import asyncadapter
+
 
 # %% Constants
 
@@ -325,8 +327,12 @@ def close_agen(agen):
     """Try to sync-close an async generator."""
     closer = agen.aclose()
     try:
-        # If the next thing is a yield, this will raise RuntimeError which we allow to propagate
-        closer.send(None)
+        # We're closing synchronously, so this is not part of the task that we
+        # may be called from; that way our own sleep() and Event() become no-ops
+        # (when no other async lib is active), and the agen can be closed.
+        with asyncadapter.detached():
+            # If the next thing is a yield, this will raise RuntimeError which we allow to propagate
+            closer.send(None)
     except StopIteration:
         pass
     else:

--- a/rendercanvas/core/loop.py
+++ b/rendercanvas/core/loop.py
@@ -532,7 +532,9 @@ class BaseLoop:
         * The subclass is responsible for cancelling remaining tasks in _rc_stop.
         * Return None.
         """
-        task = asyncadapter.Task(self._rc_call_later, async_func(), name)
+        task = asyncadapter.Task(
+            self._rc_call_later, async_func(), name, self.call_soon_threadsafe
+        )
         self.__tasks.add(task)
         task.add_done_callback(self.__tasks.discard)
 

--- a/rendercanvas/utils/asyncadapter.py
+++ b/rendercanvas/utils/asyncadapter.py
@@ -6,6 +6,7 @@ Intended for internal use, but is fully standalone.
 import weakref
 import logging
 import threading
+from contextlib import contextmanager
 
 # Support sniffio for older wgpu releases, and for code that relies on sniffio.
 try:
@@ -15,6 +16,36 @@ except ImportError:
 
 
 logger = logging.getLogger("asyncadapter")
+
+
+# Thread-local that marks the task that is currently being stepped (if any).
+# This is the authoritative way to detect that a coroutine is driven by this
+# adapter; the global asyncgen hooks cannot be trusted for that, because another
+# (native) loop may have installed its own hooks. This happens e.g. in IPython
+# with '%gui qt', where the Qt loop runs inside asyncio's input-hook, so that the
+# hooks are asyncio's while our tasks are stepped from a Qt timer.
+_thread_local = threading.local()
+
+
+def get_current_task():
+    """Get the task that is currently being stepped in this thread, or None."""
+    return getattr(_thread_local, "current_task", None)
+
+
+@contextmanager
+def detached():
+    """Context manager that hides the task that is currently being stepped.
+
+    For code that runs synchronously from inside a task, but that must not be
+    considered part of it, like the sync-closing of async generators when the
+    loop stops.
+    """
+    old_task = getattr(_thread_local, "current_task", None)
+    _thread_local.current_task = None
+    try:
+        yield
+    finally:
+        _thread_local.current_task = old_task
 
 
 class Sleeper:
@@ -72,8 +103,9 @@ class CancelledError(BaseException):
 class Task:
     """Representation of task, executing a co-routine."""
 
-    def __init__(self, call_later_func, coro, name):
+    def __init__(self, call_later_func, coro, name, call_soon_threadsafe_func=None):
         self._call_later = call_later_func
+        self._call_soon_threadsafe = call_soon_threadsafe_func
         self._done_callbacks = []
         self.coro = coro
         self.name = name
@@ -113,7 +145,9 @@ class Task:
         stop = False
 
         old_name = getattr(sniffio_thread_local, "name", None)
+        old_task = getattr(_thread_local, "current_task", None)
         sniffio_thread_local.name = __name__
+        _thread_local.current_task = self
 
         self.running = True
         try:
@@ -134,6 +168,7 @@ class Task:
         finally:
             self.running = False
             sniffio_thread_local.name = old_name
+            _thread_local.current_task = old_task
 
         # Clean up to help gc
         if stop:

--- a/rendercanvas/utils/asyncs.py
+++ b/rendercanvas/utils/asyncs.py
@@ -13,6 +13,7 @@ To give an idea how to implement a generic async sleep function:
 import sys
 
 from ..core.coreutils import IS_WIN, IS_PYODIDE, call_later_from_thread
+from . import asyncadapter
 
 
 USE_THREADED_TIMER = IS_WIN
@@ -20,10 +21,21 @@ USE_THREADED_TIMER = IS_WIN
 
 # Below detection methods use ``sys.get_asyncgen_hooks()`` for fast and robust detection.
 # Compared to sniffio, this is faster and also  works when not inside a task.
+#
+# The one case that the hooks cannot cover is when we're inside a task of our own
+# asyncadapter, while another (native) loop owns the asyncgen hooks. This happens
+# when a native loop is nested inside an async loop, e.g. in IPython with
+# '%gui qt': the Qt loop runs inside asyncio's input-hook, so the hooks are
+# asyncio's, while our tasks are stepped from a Qt timer. So we check the
+# asyncadapter first; when it is stepping a coroutine, it *is* the async lib,
+# whatever the hooks say.
 
 
 def detect_current_async_lib():
     """Get the lib name of the currently active async lib, or None."""
+
+    if asyncadapter.get_current_task() is not None:
+        return "rendercanvas.utils.asyncadapter"
 
     if IS_PYODIDE:
         return "asyncio"
@@ -50,6 +62,11 @@ def detect_current_call_soon_threadsafe():
     # We could support Pyodide too, but this never gets called on Pyodide anyway (bc USE_THREADED_TIMER). Leaving commented for reference.
     # if IS_PYODIDE:
     #     return sys.modules["asyncio"].get_running_loop().call_soon_threadsafe
+
+    # If our asyncadapter is stepping a coro, use the loop that drives it (see note above).
+    task = asyncadapter.get_current_task()
+    if task is not None and task._call_soon_threadsafe is not None:
+        return task._call_soon_threadsafe
 
     # Get asyncgen hook func, return fast when no async loop active
     ob = sys.get_asyncgen_hooks()[0]

--- a/tests/test_asyncs.py
+++ b/tests/test_asyncs.py
@@ -5,7 +5,10 @@ Test basics of rendercanvas.utils.asyncs.
 # ruff: noqa: N803
 
 import os
+import sys
 import time
+import asyncio
+import threading
 
 from rendercanvas.base import BaseCanvasGroup, BaseRenderCanvas
 from rendercanvas.asyncio import AsyncioLoop
@@ -130,6 +133,63 @@ def test_event(SomeLoop):
     sleep_time2 = times[2] - times[1]
     assert 0.04 < sleep_time1 < 0.08 + leeway
     assert 0.09 < sleep_time2 < 0.13 + leeway
+
+
+def test_sleep_when_another_loop_owns_the_asyncgen_hooks():
+    # Regression test for issue #211.
+    #
+    # When a native loop is nested inside an async loop, the asyncgen hooks
+    # belong to the outer loop, while our tasks are stepped by the inner one.
+    # This is the case in IPython with '%gui qt': the Qt loop runs inside
+    # asyncio's input-hook. Our sleep() must then still use the asyncadapter,
+    # otherwise it awaits an asyncio future that the adapter cannot handle.
+
+    leeway = 0.20 if os.getenv("CI") else 0
+
+    # A (non-running) asyncio loop to steal the asyncgen hooks with
+    asyncio_loop = asyncio.new_event_loop()
+
+    libs = []
+    funcs = []
+    times = []
+
+    async def coro():
+        sys.set_asyncgen_hooks(
+            firstiter=asyncio_loop._asyncgen_firstiter_hook,
+            finalizer=asyncio_loop._asyncgen_finalizer_hook,
+        )
+        libs.append(asyncs.detect_current_async_lib())
+        funcs.append(asyncs.detect_current_call_soon_threadsafe())
+        times.append(time.perf_counter())
+        await asyncs.sleep(0.05)
+        times.append(time.perf_counter())
+        loop.stop()
+
+    loop = RawLoop()
+    FooCanvas.select_loop(loop)
+    _canvas = FooCanvas()
+    loop.add_task(coro)
+
+    # Failsafe: without the fix the coro never resumes, so we cannot use
+    # loop.call_later() here (it relies on the very sleep that is broken then).
+    failsafe = threading.Timer(2.0, loop.call_soon_threadsafe, [loop.stop])
+    failsafe.start()
+
+    prev_hooks = sys.get_asyncgen_hooks()
+    try:
+        loop.run()
+    finally:
+        failsafe.cancel()
+        sys.set_asyncgen_hooks(*prev_hooks)
+        asyncio_loop.close()
+
+    # The adapter is stepping us, so it *is* the current async lib
+    assert libs == ["rendercanvas.utils.asyncadapter"]
+    assert funcs == [loop.call_soon_threadsafe]
+
+    # And the sleep must actually have worked
+    assert len(times) == 2
+    assert 0.04 < times[1] - times[0] < 0.08 + leeway
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes #211: `Incompatible awaitable result <Future pending>` when trying to use `rendercanvas` in `ipython` with `%gui qt`.

First the disclosure: I used Claude to write the fix.

Then the gist:

Since v2.5.0 (863f2bf, #157) `rendercanvas` detects the running async framework from the global asyncgen hooks instead of `sniffio`. Under `%gui qt` two loops are nested: `prompt_toolkit`'s asyncio loop owns the hooks, and the Qt loop runs inside its input-hook. So when a Qt timer steps an asyncadapter task, detection answers `"asyncio"`, `asyncs.sleep()` yields an asyncio `Future`, and the adapter — which only understands its own protocol — rejects it and cancels the task, including the scheduler.

The fix is to make the adapter mark the task it is stepping in a thread-local, and the detection checks that first: if the adapter is driving the coroutine, it is the `async` lib, no matter what the hooks say.

Loops on real frameworks (`asyncio`, `trio`, and hence jupyter/terminal/http/pyodide) never create adapter tasks, so they should be unaffected. 

Related:`wgpu/_async.py` seems to have a copy of the same hooks-only detection, i.e. would run into the same problem?


