### PR TITLE
Ensure utf-8 encoding for anywidget

### DIFF
--- a/rendercanvas/anywidget.py
+++ b/rendercanvas/anywidget.py
@@ -24,11 +24,11 @@ def _load_js_and_css():
     js = ""
     for fname in ["renderview.js", "renderview-afm.js"]:
         js_path = resource_files("rendercanvas.core").joinpath(fname)
-        js += js_path.read_text() + "\n\n"
+        js += js_path.read_text(encoding="utf-8") + "\n\n"
 
     css_path = resource_files("rendercanvas.core").joinpath("renderview.css")
 
-    return js, css_path.read_text()
+    return js, css_path.read_text(encoding="utf-8")
 
 
 JS, CSS = _load_js_and_css()

--- a/rendercanvas/pyodide.py
+++ b/rendercanvas/pyodide.py
@@ -27,7 +27,7 @@ def _inject_js_and_css():
     js = ""
     for fname in ["renderview.js", "renderview-pyodide.js"]:
         js_path = resource_files("rendercanvas.core").joinpath(fname)
-        js += js_path.read_text()
+        js += js_path.read_text(encoding="utf-8")
     js = "(function () {\n{JS}\n})();".replace("JS", js)  # wrap in IIFE module
     script_el = document.createElement("script")
     script_el.textContent = js
@@ -35,7 +35,7 @@ def _inject_js_and_css():
 
     css_path = resource_files("rendercanvas.core").joinpath("renderview.css")
     style_el = document.createElement("style")
-    style_el.textContent = css_path.read_text()
+    style_el.textContent = css_path.read_text(encoding="utf-8")
     document.head.appendChild(style_el)
 
 


### PR DESCRIPTION
closes https://github.com/pygfx/renderview/issues/27

I checked this in the browser and in VSCode and it now displays fine on windows (no longer this windows encoding thing, which was in the css as it loaded).
Not sure if the pyodide one is needed, since pyodide platform encoding localte is proper unicode as far as I know, but I kept it in.
Only python 3.15 has utf-8 on all platforms by default - which is years out to become minimum version.

Had to set `canvas.set_closable(False)` and then `canvas.set_closeable(True)` for it to update... not sure what that is about.