### PR TITLE
Pass the configured view_formats through to the present texture

### DIFF
--- a/rendercanvas/contexts/wgpucontext.py
+++ b/rendercanvas/contexts/wgpucontext.py
@@ -330,6 +330,7 @@ class WgpuContextToBitmap(WgpuContext):
                 size=need_texture_size,
                 format=self._config["format"],
                 usage=self._config["usage"] | self._context_texture_usage,
+                view_formats=self._config["view_formats"],
             )
 
         return self._texture

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -296,26 +296,6 @@ def test_wgpu_context_hdr():
     assert np.all(result * 255 == bitmap)
 
 
-def _create_texture_supports_view_formats(device):
-    """Whether the wgpu backend implements create_texture(view_formats=...).
-
-    It raised NotImplementedError until pygfx/wgpu-py#832, so the test below
-    would fail for a reason that has nothing to do with rendercanvas.
-    """
-    import wgpu
-
-    try:
-        device.create_texture(
-            size=(4, 4, 1),
-            format=wgpu.TextureFormat.rgba8unorm_srgb,
-            usage=wgpu.TextureUsage.RENDER_ATTACHMENT,
-            view_formats=[wgpu.TextureFormat.rgba8unorm],
-        )
-    except NotImplementedError:
-        return False
-    return True
-
-
 @pytest.mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
 def test_wgpu_context_view_formats():
     # A format passed to configure() must reach the present texture, or a view
@@ -323,9 +303,6 @@ def test_wgpu_context_view_formats():
     import wgpu
 
     device = wgpu.utils.get_default_device()
-    if not _create_texture_supports_view_formats(device):
-        pytest.skip("wgpu backend does not implement create_texture(view_formats)")
-
     usage = wgpu.TextureUsage.RENDER_ATTACHMENT | wgpu.TextureUsage.TEXTURE_BINDING
 
     canvas = ManualOffscreenRenderCanvas()
@@ -336,7 +313,19 @@ def test_wgpu_context_view_formats():
         usage=usage,
         view_formats=[wgpu.TextureFormat.rgba8unorm],
     )
-    texture = context.get_current_texture()
+
+    try:
+        texture = context.get_current_texture()
+    except NotImplementedError:
+        # create_texture() itself refuses view_formats: that is pygfx/wgpu-py#832,
+        # which is not in a wgpu release yet. Fail rather than skip -- a skip
+        # would leave this pass-through unverified while CI stayed green, and
+        # this test is the thing that tells us when the release lands.
+        pytest.fail(
+            f"wgpu {wgpu.__version__} does not implement create_texture(view_formats=..),"
+            " which this needs; see pygfx/wgpu-py#832"
+        )
+
     assert texture.format == wgpu.TextureFormat.rgba8unorm_srgb
     # The declared format is viewable: this is what the parameter is for.
     assert texture.create_view(format=wgpu.TextureFormat.rgba8unorm) is not None

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -349,7 +349,7 @@ def test_wgpu_context_view_formats():
         device=device, format=wgpu.TextureFormat.rgba8unorm_srgb, usage=usage
     )
     texture2 = context2.get_current_texture()
-    with pytest.raises(Exception):
+    with pytest.raises(wgpu.GPUValidationError, match="view format"):
         texture2.create_view(format=wgpu.TextureFormat.rgba8unorm)
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -296,5 +296,62 @@ def test_wgpu_context_hdr():
     assert np.all(result * 255 == bitmap)
 
 
+def _create_texture_supports_view_formats(device):
+    """Whether the wgpu backend implements create_texture(view_formats=...).
+
+    It raised NotImplementedError until pygfx/wgpu-py#832, so the test below
+    would fail for a reason that has nothing to do with rendercanvas.
+    """
+    import wgpu
+
+    try:
+        device.create_texture(
+            size=(4, 4, 1),
+            format=wgpu.TextureFormat.rgba8unorm_srgb,
+            usage=wgpu.TextureUsage.RENDER_ATTACHMENT,
+            view_formats=[wgpu.TextureFormat.rgba8unorm],
+        )
+    except NotImplementedError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not can_use_wgpu_lib, reason="Needs wgpu lib")
+def test_wgpu_context_view_formats():
+    # A format passed to configure() must reach the present texture, or a view
+    # in that format cannot be created and the argument silently does nothing.
+    import wgpu
+
+    device = wgpu.utils.get_default_device()
+    if not _create_texture_supports_view_formats(device):
+        pytest.skip("wgpu backend does not implement create_texture(view_formats)")
+
+    usage = wgpu.TextureUsage.RENDER_ATTACHMENT | wgpu.TextureUsage.TEXTURE_BINDING
+
+    canvas = ManualOffscreenRenderCanvas()
+    context = canvas.get_context("wgpu")
+    context.configure(
+        device=device,
+        format=wgpu.TextureFormat.rgba8unorm_srgb,
+        usage=usage,
+        view_formats=[wgpu.TextureFormat.rgba8unorm],
+    )
+    texture = context.get_current_texture()
+    assert texture.format == wgpu.TextureFormat.rgba8unorm_srgb
+    # The declared format is viewable: this is what the parameter is for.
+    assert texture.create_view(format=wgpu.TextureFormat.rgba8unorm) is not None
+
+    # Without it, the same view is rejected -- so the assertion above is
+    # testing the plumbing rather than something the backend allows anyway.
+    canvas2 = ManualOffscreenRenderCanvas()
+    context2 = canvas2.get_context("wgpu")
+    context2.configure(
+        device=device, format=wgpu.TextureFormat.rgba8unorm_srgb, usage=usage
+    )
+    texture2 = context2.get_current_texture()
+    with pytest.raises(Exception):
+        texture2.create_view(format=wgpu.TextureFormat.rgba8unorm)
+
+
 if __name__ == "__main__":
     run_tests(globals())


### PR DESCRIPTION
Allow users to configure the view_formats for the textures.

---------------------------------
From claude: 
`configure()` accepts `view_formats` and validates each against the context capabilities, and then `_get_current_texture()` creates the texture without them — so a view in any declared format fails and the argument silently does nothing. The surface-backed path already forwards them to the surface configuration; this brings the bitmap path in line, one line. Needs pygfx/wgpu-py#832 and is inert until it lands, so the test skips when the backend does not implement `create_texture(view_formats=...)`.
